### PR TITLE
many neutron-ha-tool fixes

### DIFF
--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -423,8 +423,9 @@ def migrate_router(qclient, router_id, agent_id, target_id):
     # subsequent failure during the add or remove process so we must check to
     # ensure the router has been added or removed
 
-    # remove the router from the dead agent
+    # Remove the router from the original agent
     qclient.remove_router_from_l3_agent(agent_id, router_id)
+    LOG.debug("Removed router from agent=%s" % agent_id)
 
     # ensure it is removed or log an error
     if router_id in list_routers_on_l3_agent(qclient, agent_id):

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -286,8 +286,9 @@ def l3_agent_migrate(qclient, noop=False, now=False):
         return
 
     if len(agent_alive_list) < 1:
-        LOG.exception("There are no l3 agents alive to migrate "
-                      "routers onto")
+        LOG.error("There are no l3 agents alive to migrate routers onto - "
+                  "aborting!")
+        return
 
     timeout = 0
     if not now:
@@ -347,8 +348,8 @@ def l3_agent_evacuate(qclient, excludeagent, noop=False):
     migration_count = 0
 
     if len(target_list) < 1:
-        LOG.exception("There are no l3 agents alive to migrate "
-                      "routers onto")
+        LOG.error("There are no l3 agents alive to migrate routers onto")
+        return
 
     agent_to_exclude = None
     for agent in agent_list:

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -358,7 +358,8 @@ def l3_agent_evacuate(qclient, excludeagent, noop=False):
             break
 
     if not agent_to_exclude:
-        LOG.exception("Could not locate agent to evacuate")
+        LOG.error("Could not locate agent to evacuate; aborting!")
+        return
 
     agent_id = agent_to_exclude['id']
     LOG.info("Querying agent_id=%s for routers to migrate", agent_id)

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -32,6 +32,7 @@ LOG_FORMAT = '%(asctime)s %(name)-12s %(levelname)-8s %(message)s'
 LOG_DATE = '%m-%d %H:%M'
 DESCRIPTION = "neutron High Availability Tool"
 TAKEOVER_DELAY = int(random.random()*30+30)
+OS_PASSWORD_FILE = '/etc/neutron/os_password'
 
 
 def parse_args():
@@ -94,9 +95,13 @@ def run(args):
     # backwards-compatibility and follows conventional precedence.
     if os.getenv('OS_PASSWORD'):
         os_password = os.environ['OS_PASSWORD']
-    else:
-        with open('/etc/neutron/os_password') as f:
+    elif os.path.exists(OS_PASSWORD_FILE):
+        with open(OS_PASSWORD_FILE) as f:
             os_password = f.readline()
+    else:
+        LOG.fatal("Couldn't retrieve password from $OS_PASSWORD environment "
+                  "or from %s; aborting!" % OS_PASSWORD_FILE)
+        sys.exit(1)
 
     # instantiate client
     qclient = client.Client('2.0', auth_url=os.environ['OS_AUTH_URL'],

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -317,7 +317,8 @@ def l3_agent_migrate(qclient, noop=False, now=False):
     :param qclient: A neutronclient
     :param noop: Optional noop flag
     :param now: Optional. If false (the default), we'll wait for a random
-                amount of time (between 30 and 60 seconds) before migration. If
+                amount of time (between 30 and 60 seconds) before migration,
+                and if an agent comes online, migration is abandoned. If
                 true, routers are migrated immediately.
 
     """

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -69,7 +69,24 @@ def parse_args():
                          'certificate will not be verified against any '
                          'certificate authorities. This option should be used '
                          'with caution.')
-    return ap.parse_args()
+    args = ap.parse_args()
+    modes = [
+        args.l3_agent_check,
+        args.l3_agent_migrate,
+        args.l3_agent_evacuate,
+        args.l3_agent_rebalance,
+        args.replicate_dhcp,
+    ]
+    if sum(1 for x in modes if x) != 1:
+        args_error(ap, "You must choose exactly one action")
+    return args
+
+
+# Replacement for ArgumentParser.error() which is hardcoded to exit 2,
+# clashing with our meaning of exit code 2.
+def args_error(ap, message):
+    ap.print_usage()
+    ap.exit(3, '%s: error: %s\n' % (ap.prog, message))
 
 
 def setup_logging(args):
@@ -120,20 +137,20 @@ def run(args):
         LOG.info("Performing L3 Agent Health Check")
         l3_agent_check(qclient)
 
-    if args.l3_agent_migrate:
+    elif args.l3_agent_migrate:
         LOG.info("Performing L3 Agent Migration for Offline L3 Agents")
         l3_agent_migrate(qclient, args.noop, args.now)
 
-    if args.l3_agent_evacuate:
+    elif args.l3_agent_evacuate:
         LOG.info("Performing L3 Agent Evacuation from agent %s",
                  args.l3_agent_evacuate)
         l3_agent_evacuate(qclient, args.l3_agent_evacuate, args.noop)
 
-    if args.l3_agent_rebalance:
+    elif args.l3_agent_rebalance:
         LOG.info("Rebalancing L3 Agent Router Count")
         l3_agent_rebalance(qclient, args.noop)
 
-    if args.replicate_dhcp:
+    elif args.replicate_dhcp:
         LOG.info("Performing DHCP Replication of Networks to Agents")
         replicate_dhcp(qclient, args.noop)
 

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -255,7 +255,7 @@ def l3_agent_rebalance(qclient, noop=False):
         low_agent_router_count = len(l3_agent_dict[low_agent_id])
         hgh_agent_router_count = len(l3_agent_dict[hgh_agent_id])
 
-        LOG.info("Low Count=%s, High Count=%s",
+        LOG.info("Low Count=%d, High Count=%d",
                  low_agent_router_count, hgh_agent_router_count)
 
         for router_id in l3_agent_dict[hgh_agent_id]:
@@ -282,7 +282,7 @@ def l3_agent_check(qclient):
     agent_list = list_agents(qclient)
     agent_dead_list = agent_dead_id_list(agent_list, 'L3 agent')
     agent_alive_list = agent_alive_id_list(agent_list, 'L3 agent')
-    LOG.info("There are %s offline L3 agents and %s online L3 agents",
+    LOG.info("There are %d offline L3 agents and %d online L3 agents",
              len(agent_dead_list), len(agent_alive_list))
 
     if len(agent_dead_list) == 0:
@@ -326,7 +326,7 @@ def l3_agent_migrate(qclient, noop=False, now=False):
     agent_list = list_agents(qclient)
     agent_dead_list = agent_dead_id_list(agent_list, 'L3 agent')
     agent_alive_list = agent_alive_id_list(agent_list, 'L3 agent')
-    LOG.info("There are %s offline L3 agents and %s online L3 agents",
+    LOG.info("There are %d offline L3 agents and %d online L3 agents",
              len(agent_dead_list), len(agent_alive_list))
 
     if len(agent_dead_list) == 0:
@@ -345,12 +345,12 @@ def l3_agent_migrate(qclient, noop=False, now=False):
                                                      'L3 agent')
             if len(agent_dead_list_new) < len(agent_dead_list):
                 LOG.info("Skipping router failover since an agent came "
-                         "online while ensuring agents offline for %s "
+                         "online while ensuring agents offline for %d "
                          "seconds", TAKEOVER_DELAY)
                 sys.exit(0)
 
-            LOG.info("Agent found offline for seconds=%s but waiting "
-                     "seconds=%s before migration",
+            LOG.info("Agent found offline for seconds=%d but waiting "
+                     "seconds=%d before migration",
                      timeout, TAKEOVER_DELAY)
             timeout += 1
             time.sleep(1)
@@ -360,7 +360,7 @@ def l3_agent_migrate(qclient, noop=False, now=False):
         migration_count += migrate_l3_routers_from_agent(
             qclient, agent_id, agent_alive_list, noop)
 
-    LOG.info("%s routers required migration from offline L3 agents",
+    LOG.info("%d routers required migration from offline L3 agents",
              migration_count)
 
 
@@ -395,7 +395,7 @@ def l3_agent_evacuate(qclient, excludeagent, noop=False):
     agent_id = agent_to_exclude['id']
     migration_count = \
         migrate_l3_routers_from_agent(qclient, agent_id, target_list, noop)
-    LOG.info("%s routers required evacuation from L3 agent %s",
+    LOG.info("%d routers required evacuation from L3 agent %s",
              migration_count, excludeagent)
 
 
@@ -413,7 +413,7 @@ def replicate_dhcp(qclient, noop=False):
     networks = list_networks(qclient)
     network_id_list = [n['id'] for n in networks]
     agents = list_agents(qclient, agent_type='DHCP agent')
-    LOG.info("Replicating %s networks to %s DHCP agents", len(networks),
+    LOG.info("Replicating %d networks to %d DHCP agents", len(networks),
              len(agents))
     for dhcp_agent_id in [a['id'] for a in agents]:
         networks_on_agent = \
@@ -435,7 +435,7 @@ def replicate_dhcp(qclient, noop=False):
                               "dhcp_agent=%s", network_id, dhcp_agent_id)
                 continue
 
-    LOG.info("Added %s networks to DHCP agents", added)
+    LOG.info("Added %d networks to DHCP agents", added)
 
 
 def migrate_l3_routers_from_agent(qclient, agent_id, target_ids, noop):

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -416,7 +416,7 @@ def replicate_dhcp(qclient, noop=False):
 
 def migrate_router(qclient, router_id, agent_id, target_id):
     """
-    Returns nothing, and raises on exception
+    Returns nothing, and raises exceptions on errors.
 
     :param qclient: A neutronclient
     :param router_id: The id of the router to migrate
@@ -433,8 +433,8 @@ def migrate_router(qclient, router_id, agent_id, target_id):
 
     # ensure it is removed or log an error
     if router_id in list_routers_on_l3_agent(qclient, agent_id):
-        LOG.exception("Failed to remove router_id=%s from agent_id=%s",
-                      router_id, agent_id)
+        raise RuntimeError("Failed to remove router_id=%s from agent_id=%s",
+                           router_id, agent_id)
 
     # add the router id to a live agent
     router_body = {'router_id': router_id}
@@ -442,8 +442,8 @@ def migrate_router(qclient, router_id, agent_id, target_id):
 
     # ensure it is removed or log an error
     if router_id not in list_routers_on_l3_agent(qclient, target_id):
-        LOG.exception("Failed to add router_id=%s from agent_id=%s",
-                      router_id, agent_id)
+        raise RuntimeError("Failed to add router_id=%s from agent_id=%s",
+                           router_id, agent_id)
 
 
 def list_networks(qclient):

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -205,8 +205,6 @@ def l3_agent_rebalance(qclient, noop=False):
             if low_agent_router_count >= hgh_agent_router_count:
                 break
             else:
-                LOG.info("Migrating router=%s from agent=%s to agent=%s",
-                         router_id, hgh_agent_id, low_agent_id)
                 try:
                     if not noop:
                         migrate_router(qclient, router_id, hgh_agent_id,
@@ -314,8 +312,6 @@ def l3_agent_migrate(qclient, noop=False, now=False):
 
         for router_id in router_id_list:
             target_id = random.choice(agent_alive_list)
-            LOG.info("Migrating router=%s to agent=%s",
-                     router_id, target_id)
 
             try:
                 if not noop:
@@ -365,8 +361,6 @@ def l3_agent_evacuate(qclient, excludeagent, noop=False):
 
     for router_id in router_id_list:
         target_id = random.choice(target_list)
-        LOG.info("Migrating router=%s to agent=%s",
-                 router_id, target_id)
 
         try:
             if not noop:
@@ -427,6 +421,9 @@ def migrate_router(qclient, router_id, agent_id, target_id):
     :param agent_id: The id of the l3 agent to migrate from
     :param target_id: The id of the l3 agent to migrate to
     """
+
+    LOG.info("Migrating router=%s from agent=%s to agent=%s",
+             router_id, agent_id, target_id)
 
     # N.B. The neutron API will return "success" even when there is a
     # subsequent failure during the add or remove process so we must check to

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -310,6 +310,7 @@ def l3_agent_migrate(qclient, noop=False, now=False):
     for agent_id in agent_dead_list:
         LOG.info("Querying agent_id=%s for routers to migrate", agent_id)
         router_id_list = list_routers_on_l3_agent(qclient, agent_id)
+        migration_count += len(router_id_list)
 
         for router_id in router_id_list:
             target_id = random.choice(agent_alive_list)
@@ -319,7 +320,6 @@ def l3_agent_migrate(qclient, noop=False, now=False):
             try:
                 if not noop:
                     migrate_router(qclient, router_id, agent_id, target_id)
-                    migration_count += 1
             except:
                 LOG.exception("There was an error migrating a router")
                 continue
@@ -361,6 +361,7 @@ def l3_agent_evacuate(qclient, excludeagent, noop=False):
     agent_id = agent_to_exclude['id']
     LOG.info("Querying agent_id=%s for routers to migrate", agent_id)
     router_id_list = list_routers_on_l3_agent(qclient, agent_id)
+    migration_count += len(router_id_list)
 
     for router_id in router_id_list:
         target_id = random.choice(target_list)
@@ -373,7 +374,6 @@ def l3_agent_evacuate(qclient, excludeagent, noop=False):
         except Exception:
             LOG.exception("There was an error migrating a router")
             continue
-        migration_count += 1
 
     LOG.info("%s routers required migration from L3 agent %s",
              migration_count, excludeagent)

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -35,7 +35,6 @@ TAKEOVER_DELAY = int(random.random()*30+30)
 
 
 def parse_args():
-
     # ensure environment has necessary items to authenticate
     for key in ['OS_TENANT_NAME', 'OS_USERNAME',
                 'OS_AUTH_URL', 'OS_REGION_NAME']:
@@ -293,7 +292,6 @@ def l3_agent_migrate(qclient, noop=False, now=False):
     timeout = 0
     if not now:
         while timeout < TAKEOVER_DELAY:
-
             agent_list_new = list_agents(qclient)
             agent_dead_list_new = agent_dead_id_list(agent_list_new,
                                                      'L3 agent')
@@ -314,7 +312,6 @@ def l3_agent_migrate(qclient, noop=False, now=False):
         router_id_list = list_routers_on_l3_agent(qclient, agent_id)
 
         for router_id in router_id_list:
-
             target_id = random.choice(agent_alive_list)
             LOG.info("Migrating router=%s to agent=%s",
                      router_id, target_id)

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -40,7 +40,9 @@ def parse_args():
     for key in ['OS_TENANT_NAME', 'OS_USERNAME',
                 'OS_AUTH_URL', 'OS_REGION_NAME']:
         if key not in os.environ.keys():
-            LOG.exception("Your environment is missing '%s'")
+            # We don't have a logger set up yet
+            sys.stderr.write("Your environment is missing '%s'\n" % key)
+            sys.exit(1)
 
     ap = argparse.ArgumentParser(description=DESCRIPTION)
     ap.add_argument('-d', '--debug', action='store_true',

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -603,9 +603,9 @@ def target_agent_list(agent_list, agent_type, excludeagent):
 
     """
     return [agent['id'] for agent in agent_list
-            if agent['agent_type'] == agent_type
-            and agent['alive']
-            and agent['host'] != excludeagent]
+            if agent['agent_type'] == agent_type and
+            agent['alive'] and
+            agent['host'] != excludeagent]
 
 
 def agent_dead_id_list(agent_list, agent_type):

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -58,7 +58,7 @@ def parse_args():
                     help='Show routers associated with offline l3 agents')
     ap.add_argument('--l3-agent-migrate', action='store_true', default=False,
                     help='Migrate routers away from offline l3 agents')
-    ap.add_argument('--l3-agent-evacuate', default=None,
+    ap.add_argument('--l3-agent-evacuate', default=None, metavar='AGENT_ID',
                     help='Migrate routers away from a particular l3 agent')
     ap.add_argument('--l3-agent-rebalance', action='store_true', default=False,
                     help='Rebalance router count on all l3 agents')


### PR DESCRIPTION
**In a Crowbar environment, the retry commit requires https://github.com/crowbar/crowbar-openstack/pull/344 and also https://review.openstack.org/#/c/297664/ in order to be effective.**

Whilst looking into [bsc#965886 (L3: neutron-ha-tool not migrating dhcp networks during failover)](https://bugzilla.suse.com/show_bug.cgi?id=965886), I discovered many instances of braindead code in `neutron-ha-tool`.  In particular, previous authors seemed to think that `LOG.exception()` aborts the code flow, which it doesn't, so several corner cases just completely fail.

Rather than submitting all these changes as individual rpm patches like it's 1995, I've forked the original upstream git repo to this fork, resurrected the Icehouse branch (which was tagged as `eol-icehouse`) and created a new `neutron-ha-tool-maintenance` branch from it which can be subject to the normal code review process.  We can then easily repoint https://build.suse.de/package/show/Devel:Cloud:6:Staging/openstack-neutron at it.  Similarly for Cloud 5.
