### PR TITLE
Retry on errors, not just NeutronExceptions (bsc#965886)

### DIFF
--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -440,6 +440,7 @@ def replicate_dhcp(qclient, noop=False):
 
     :param qclient: A neutronclient
     :param noop: Optional noop flag
+    :returns: total number of errors encountered
 
     """
 

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -126,6 +126,10 @@ def retry_neutron_exceptions(exception):
     return isinstance(exception, NeutronException)
 
 
+def retry_on_errors(num_errors):
+    return num_errors > 0
+
+
 def retry_with_backoff(fn, args):
     if not args.retry:
         return fn
@@ -133,7 +137,8 @@ def retry_with_backoff(fn, args):
     return retrying.retry(
         wait_exponential_multiplier=250,
         wait_exponential_max=args.retry_max_interval,
-        retry_on_exception=retry_neutron_exceptions
+        retry_on_exception=retry_neutron_exceptions,
+        retry_on_result=retry_on_errors
     )(fn)
 
 


### PR DESCRIPTION
So far `neutron-ha-tool.py` only retries if there is a `NeutronException` response from neutron, which typically happens when Keystone cannot authenticate due to lack of a running database.

However it does not retry a migration / rebalance / DHCP replication if errors are experienced during the operation, e.g. if there are no L3 agents online, which would prevent any migration.  This is problematic because when invoked via the corresponding Pacemaker OCF resource agent, Pacemaker will rapidly fail the `neutron-ha-tool` resource and give up any further retries, which could lead to network outages for VM instances which no longer have their required routers running on any healthy L3 agent.

Therefore we retry on errors in addition to retrying on exceptions from `python-neutronclient`.

https://bugzilla.suse.com/show_bug.cgi?id=965886
