### PR TITLE
Use the least busy agent as destination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@
 .vagrant/
 .coverage/
 *.swp
+*.pyc
+.coverage
 Vagrantfile

--- a/files/default/README.md
+++ b/files/default/README.md
@@ -11,3 +11,7 @@ Run the tests
 Coverage report
 
     coverage report -i neutron-ha-tool.py
+
+Code analysis
+
+	flake8 neutron-ha-tool.py test-neutron-ha-tool.py

--- a/files/default/README.md
+++ b/files/default/README.md
@@ -1,0 +1,13 @@
+# Unit Testing
+
+Make a python 2 virtual environment, activate it, and install the requirements:
+
+    pip install -r test-requirements.txt
+
+Run the tests
+
+    coverage run test-neutron-ha-tool.py
+
+Coverage report
+
+    coverage report -i neutron-ha-tool.py

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -552,8 +552,9 @@ def migrate_l3_routers_from_agent(qclient, agent, targets,
 
     migrations = 0
     errors = 0
+    agent_picker = RandomAgentPicker(targets)
     for router_id in router_id_list:
-        target = random.choice(targets)
+        target = agent_picker.pick()
         if migrate_router_safely(qclient, noop, router_id, agent,
                                  target, wait_for_router, delete_namespace):
             migrations += 1
@@ -902,6 +903,14 @@ def list_dead_agents(agent_list, agent_type):
     """
     return [agent for agent in agent_list
             if agent['agent_type'] == agent_type and agent['alive'] is False]
+
+
+class RandomAgentPicker(object):
+    def __init__(self, agents):
+        self.agents = agents
+
+    def pick(self):
+        return random.choice(self.agents)
 
 
 if __name__ == '__main__':

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -106,12 +106,12 @@ def parse_args():
                          'some reason.')
     wait_parser = ap.add_mutually_exclusive_group(required=False)
     wait_parser.add_argument('--wait-for-router', action='store_true',
-                    dest='wait_for_router')
+                             dest='wait_for_router')
     wait_parser.add_argument('--no-wait-for-router', action='store_false',
-                    dest='wait_for_router',
-                    help='When migrating routers, do not wait for its ports and '
-                         'floating IPs to be ACTIVE again on the target '
-                         'agent.')
+                             dest='wait_for_router',
+                             help='When migrating routers, do not wait for '
+                                  'its ports and floating IPs to be ACTIVE '
+                                  'again on the target agent.')
     wait_parser.set_defaults(wait_for_router=True)
     args = ap.parse_args()
     modes = [
@@ -307,8 +307,8 @@ def l3_agent_rebalance(qclient, noop=False, wait_for_router=True):
         routers_on_l3_agent_dict[l3_agent['id']] = \
             list_routers_on_l3_agent(qclient, l3_agent['id'])
 
-    ordered_l3_agent_dict = OrderedDict(sorted(routers_on_l3_agent_dict.items(),
-                                               key=lambda t: len(t[0])))
+    ordered_l3_agent_dict = OrderedDict(
+        sorted(routers_on_l3_agent_dict.items(), key=lambda t: len(t[0])))
     ordered_l3_agent_list = list(ordered_l3_agent_dict)
     num_agents = len(ordered_l3_agent_list)
     LOG.info("Agent list: %s",
@@ -764,7 +764,7 @@ def list_routers(qclient):
     resp = qclient.list_routers()
     LOG.debug("list_routers: %s", resp)
     # Filter routers to not include HA routers
-    return [i for i in resp['routers'] if not i.get('ha') == True]
+    return [i for i in resp['routers'] if not i.get('ha') == True]  # noqa
 
 
 def list_routers_on_l3_agent(qclient, agent_id):
@@ -776,7 +776,7 @@ def list_routers_on_l3_agent(qclient, agent_id):
 
     resp = qclient.list_routers_on_l3_agent(agent_id)
     LOG.debug("list_routers_on_l3_agent: %s", resp)
-    return [r['id'] for r in resp['routers'] if not r.get('ha') == True]
+    return [r['id'] for r in resp['routers'] if not r.get('ha') == True]  # noqa
 
 
 def list_agents(qclient, agent_type=None):

--- a/files/default/test-neutron-ha-tool.py
+++ b/files/default/test-neutron-ha-tool.py
@@ -1,0 +1,149 @@
+import unittest
+import collections
+import importlib
+import logging
+ha_tool = importlib.import_module("neutron-ha-tool")
+
+
+class MockNeutronClient(object):
+
+    def __init__(self):
+        self.routers = {}
+        self.agents = {}
+        self.routers_by_agent = collections.defaultdict(set)
+
+    def tst_add_agent(self, agent_id, props):
+        self.agents[agent_id] = dict(props, id=agent_id)
+
+    def tst_add_router(self, agent_id, router_id, props):
+        self.routers[router_id] = dict(props, id=router_id)
+        self.routers_by_agent[agent_id].add(router_id)
+
+    def tst_agent_by_router(self, router_id):
+        for agent_id, router_ids in self.routers_by_agent.items():
+            if router_id in router_ids:
+                return self.agents[agent_id]
+
+        raise NotImplementedError()
+
+    def list_agents(self):
+        return {
+            'agents': self.agents.values()
+        }
+
+    def list_routers_on_l3_agent(self, agent_id):
+        return {
+            'routers': [
+                self.routers[router_id]
+                for router_id in self.routers_by_agent[agent_id]
+            ]
+        }
+
+    def remove_router_from_l3_agent(self, agent_id, router_id):
+        self.routers_by_agent[agent_id].remove(router_id)
+
+    def add_router_to_l3_agent(self, agent_id, router_body):
+        self.routers_by_agent[agent_id].add(router_body['router_id'])
+
+    def list_ports(self, device_id, fields):
+        return {
+            'ports': [
+                {
+                    'id': 'someid',
+                    'binding:host_id':
+                        self.tst_agent_by_router(device_id)['host'],
+                    'binding:vif_type': 'non distributed',
+                    'status': 'ACTIVE'
+                }
+            ]
+        }
+
+    def list_floatingips(self, router_id):
+        return {
+            'floatingips': [
+                {
+                    'id': 'irrelevant',
+                    'status': 'ACTIVE'
+                }
+            ]
+        }
+
+
+def make_neturon_client(live_agents=0, dead_agents=0):
+    neutron_client = MockNeutronClient()
+
+    for i in range(live_agents):
+        neutron_client.tst_add_agent(
+            'live-agent-{}'.format(i), {
+                'agent_type': 'L3 agent',
+                'alive': True,
+                'admin_state_up': True,
+                'host': 'live-agent-{}-host'.format(i),
+                'configurations': {
+                    'agent_mode': 'Mode X'
+                }
+            }
+        )
+    for i in range(dead_agents):
+        neutron_client.tst_add_agent(
+            'dead-agent-{}'.format(i), {
+                'agent_type': 'L3 agent',
+                'alive': False,
+                'admin_state_up': False,
+                'host': 'dead-agent-{}-host'.format(i)
+            }
+        )
+    return neutron_client
+
+
+class TestL3AgentMigrate(unittest.TestCase):
+
+    def test_no_dead_agents_returns_zero(self):
+        neutron_client = make_neturon_client(live_agents=2)
+
+        result = ha_tool.l3_agent_migrate(neutron_client)
+
+        self.assertEqual(0, result)
+
+    def test_no_alive_agents_returns_one(self):
+        neutron_client = make_neturon_client(dead_agents=2)
+
+        result = ha_tool.l3_agent_migrate(neutron_client)
+
+        self.assertEqual(1, result)
+
+    def test_router_moved(self):
+        neutron_client = make_neturon_client(live_agents=1, dead_agents=1)
+        neutron_client.tst_add_router('dead-agent-0', 'router-1', {})
+
+        result = ha_tool.l3_agent_migrate(neutron_client, now=True)
+
+        self.assertEqual(0, result)
+        self.assertEqual(
+            set(['router-1']), neutron_client.routers_by_agent['live-agent-0'])
+
+
+class TestL3AgentEvacuate(unittest.TestCase):
+
+    def test_no_agents_returns_zero(self):
+        neutron_client = MockNeutronClient()
+        result = ha_tool.l3_agent_evacuate(neutron_client, 'host1')
+
+        self.assertEqual(0, result)
+
+    def test_evacuation(self):
+        neutron_client = make_neturon_client(live_agents=2)
+        neutron_client.tst_add_router('live-agent-0', 'router', {})
+
+        result = ha_tool.l3_agent_evacuate(neutron_client, 'live-agent-0-host')
+
+        self.assertEqual(0, result)
+        self.assertEqual(
+            set(['router']),
+            neutron_client.routers_by_agent['live-agent-1']
+        )
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()

--- a/files/default/test-requirements.txt
+++ b/files/default/test-requirements.txt
@@ -1,4 +1,5 @@
 coverage
+flake8
 
 retrying
 python-neutronclient

--- a/files/default/test-requirements.txt
+++ b/files/default/test-requirements.txt
@@ -1,0 +1,5 @@
+coverage
+
+retrying
+python-neutronclient
+python-keystoneclient


### PR DESCRIPTION
This change allows people to select which agent to use as a destination while moving routers. By default the choice was random. This patch changes the default to select always the least busy agent. The least busy agent has the smallest number of routers on it. If people want the random behaviour, they can select it with the --agent-selection-mode=random command line switch.

The new method first asks for the list of routers on each of the target agents, and saves this information in a cache. Each time when an agent is picked, the method is assuming that the move was successful, and maintains it's internal state accordingly. The cache of routers per agent will expire after 5 minutes, in which case neutron will be queried again.