### PR TITLE
Allow selection of target agent

### DIFF
--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -1007,6 +1007,40 @@ def load_router_ids(path):
     return router_ids
 
 
+class AgentIdBasedAgentPicker(object):
+    def __init__(self, agent_id):
+        self.agents = []
+        self.agent_id = agent_id
+
+    def set_agents(self, agents):
+        self.agents = agents
+
+    def pick(self):
+        for agent in self.agents:
+            if agent.get('id') == self.agent_id:
+                return agent
+        raise IndexError(
+            'Cannot find agent with agent id: {}'.format(self.agent_id)
+        )
+
+
+class HostBasedAgentPicker(object):
+    def __init__(self, host):
+        self.agents = []
+        self.host = host
+
+    def set_agents(self, agents):
+        self.agents = agents
+
+    def pick(self):
+        for agent in self.agents:
+            if agent.get('host') == self.host:
+                return agent
+        raise IndexError(
+            'Cannot find agent with host: {}'.format(self.host)
+        )
+
+
 if __name__ == '__main__':
     args = parse_args()
     setup_logging(args)

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -117,6 +117,12 @@ def parse_args():
                          'moved. The router list file should specify one '
                          'router id per line. This only applies for '
                          'agent evacuation.')
+    ap.add_argument('--target-agent-id', default=None,
+                    help='Explicitly select a target agent by specifying an '
+                         'agent id.')
+    ap.add_argument('--target-host', default=None,
+                    help='Explicitly select a target agent by specifying its '
+                         'host.')
     wait_parser = ap.add_mutually_exclusive_group(required=False)
     wait_parser.add_argument('--wait-for-router', action='store_true',
                              dest='wait_for_router')
@@ -247,6 +253,11 @@ def run(args):
         agent_picker = LeastBusyAgentPicker(qclient)
     else:
         raise ValueError('Invalid agent_selection_mode')
+
+    if args.target_agent_id:
+        agent_picker = AgentIdBasedAgentPicker(args.target_agent_id)
+    if args.target_host:
+        agent_picker = HostBasedAgentPicker(args.target_host)
 
     if args.l3_agent_check:
         LOG.info("Performing L3 Agent Health Check")

--- a/files/default/test-neutron-ha-tool.py
+++ b/files/default/test-neutron-ha-tool.py
@@ -309,6 +309,65 @@ class TestWhitelistRouterFilter(unittest.TestCase):
         self.assertEqual(['router-id-1'], filtered_router_ids)
 
 
+class TestAgentIdBasedAgentPicker(unittest.TestCase):
+
+    def make_picker(self, agent_id):
+        picker = ha_tool.AgentIdBasedAgentPicker(agent_id)
+        picker.set_agents(
+            [
+                {'id': 'live-agent-0', 'host': 'host-0'},
+                {'id': 'live-agent-1', 'host': 'host-1'}
+            ]
+        )
+        return picker
+
+    def test_picking_an_agent_by_agent_id(self):
+        picker = self.make_picker('live-agent-0')
+
+        picked_agent = picker.pick()
+
+        self.assertEqual('live-agent-0', picked_agent['id'])
+
+    def test_agent_not_found_raises_index_error(self):
+        picker = self.make_picker('invalid')
+
+        with self.assertRaises(IndexError) as ctx:
+            picker.pick()
+
+        self.assertEqual(
+            'Cannot find agent with agent id: invalid', str(ctx.exception))
+
+
+class TestHostBasedAgentPicker(unittest.TestCase):
+
+    def make_picker(self, host):
+        picker = ha_tool.HostBasedAgentPicker(host)
+        picker.set_agents(
+            [
+                {'id': 'live-agent-0', 'host': 'host-0'},
+                {'id': 'live-agent-1', 'host': 'host-1'}
+            ]
+        )
+        return picker
+
+    def test_picking_an_agent_by_host(self):
+        picker = self.make_picker('host-0')
+
+        picked_agent = picker.pick()
+
+        self.assertEqual('host-0', picked_agent['host'])
+
+
+    def test_agent_not_found_by_host_id_raises_index_error(self):
+        picker = self.make_picker('invalid')
+
+        with self.assertRaises(IndexError) as ctx:
+            picker.pick()
+
+        self.assertEqual(
+            'Cannot find agent with host: invalid', str(ctx.exception))
+
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)
     unittest.main()


### PR DESCRIPTION
Enable users to specify explicitly a target agent for router migration either by using an agent id or a host id