### PR TITLE
Implement router list file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@
 .vagrant/
 .coverage/
 *.swp
+*.pyc
+.coverage
 Vagrantfile

--- a/files/default/README.md
+++ b/files/default/README.md
@@ -1,0 +1,17 @@
+# Unit Testing
+
+Make a python 2 virtual environment, activate it, and install the requirements:
+
+    pip install -r test-requirements.txt
+
+Run the tests
+
+    coverage run test-neutron-ha-tool.py
+
+Coverage report
+
+    coverage report -i neutron-ha-tool.py
+
+Code analysis
+
+	flake8 neutron-ha-tool.py test-neutron-ha-tool.py

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -23,6 +23,7 @@
 
 import argparse
 from collections import OrderedDict
+import datetime
 import logging
 from logging.handlers import SysLogHandler
 import os
@@ -52,6 +53,8 @@ IDENTITY_API_VERSIONS = {
     '2': kclientv2,
     '3': kclientv3
 }
+
+ROUTER_CACHE_MAX_AGE_SECONDS = 5 * 60
 
 
 def parse_args():
@@ -920,6 +923,41 @@ class RandomAgentPicker(object):
 
     def pick(self):
         return random.choice(self.agents)
+
+
+class LeastBusyAgentPicker(object):
+    def __init__(self, qclient, agents):
+        self.now = datetime.datetime.now
+        self.cache_created_at = None
+        self.qclient = qclient
+        self.agents_by_id = {agent['id']: agent for agent in agents}
+        self.router_count_per_agent_id = {}
+        self.refresh_router_count_per_agent_id()
+
+    def refresh_router_count_per_agent_id(self):
+        LOG.info("Refreshing router count per agent cache")
+        self.router_count_per_agent_id = dict()
+        for agent_id in self.agents_by_id:
+            self.router_count_per_agent_id[agent_id] = len(
+                list_routers_on_l3_agent(self.qclient, agent_id)
+            )
+        self.cache_created_at = self.now()
+
+    def cache_expired(self):
+        cache_life = self.now() - self.cache_created_at
+        return cache_life.total_seconds() > ROUTER_CACHE_MAX_AGE_SECONDS
+
+    def pick(self):
+        if self.cache_expired():
+            self.refresh_router_count_per_agent_id()
+
+        agent_id_number_of_routers = sorted(
+            self.router_count_per_agent_id.items(),
+            key=lambda x: (x[1], x[0])
+        )
+        agent_id = agent_id_number_of_routers[0][0]
+        self.router_count_per_agent_id[agent_id] += 1
+        return self.agents_by_id[agent_id]
 
 
 class Configuration(object):

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -964,6 +964,27 @@ class LeastBusyAgentPicker(object):
         return self.agents_by_id[agent_id]
 
 
+class SingleAgentPicker(object):
+    agent_keys = ('id', 'host')
+    agent_selection_value = None
+
+    def __init__(self, qclient, agents):
+        self.agents = agents
+
+    def find_agent(self, value):
+        for agent in self.agents:
+            agent_values = [agent.get(key) for key in self.agent_keys]
+            if value in agent_values:
+                return agent
+        raise IndexError('Cannot find desired agent')
+
+    def pick(self):
+        if not self.agent_selection_value:
+            raise ValueError('agent_selection_value is None')
+
+        return self.find_agent(self.agent_selection_value)
+
+
 class Configuration(object):
     """
     Registry for storing application's configuration

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -552,8 +552,9 @@ def migrate_l3_routers_from_agent(qclient, agent, targets,
 
     migrations = 0
     errors = 0
+    agent_picker = RandomAgentPicker(targets)
     for router_id in router_id_list:
-        target = random.choice(targets)
+        target = agent_picker.pick()
         if migrate_router_safely(qclient, noop, router_id, agent,
                                  target, wait_for_router, delete_namespace):
             migrations += 1
@@ -902,6 +903,14 @@ def list_dead_agents(agent_list, agent_type):
     """
     return [agent for agent in agent_list
             if agent['agent_type'] == agent_type and agent['alive'] is False]
+
+
+class RandomAgentPicker(object):
+    def __init__(self, agents):
+        self.agents = agents
+
+    def pick(self):
+        return random.choice(self.agents)
 
 
 if __name__ == '__main__':

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -107,10 +107,11 @@ def parse_args():
                          'is mainly useful when evacuating routers from '
                          'a node where the l3-agent is not running for '
                          'some reason.')
-    ap.add_argument('--agent-selection-mode', choices=['random'],
-                    default='random',
+    ap.add_argument('--agent-selection-mode', choices=['random', 'least-busy'],
+                    default='least-busy',
                     help='Determines how target agent is selected for routers '
-                         '"random" selects target agent randomly.')
+                         '"random" selects target agent randomly, '
+                         '"least-busy" selects the least busy agent.')
     wait_parser = ap.add_mutually_exclusive_group(required=False)
     wait_parser.add_argument('--wait-for-router', action='store_true',
                              dest='wait_for_router')
@@ -237,6 +238,8 @@ def run(args):
 
     if args.agent_selection_mode == 'random':
         Configuration.agent_picker_class = RandomAgentPicker
+    elif args.agent_selection_mode == 'least-busy':
+        Configuration.agent_picker_class = LeastBusyAgentPicker
     else:
         raise ValueError('Invalid agent_selection_mode')
 
@@ -564,7 +567,7 @@ def migrate_l3_routers_from_agent(qclient, agent, targets,
 
     migrations = 0
     errors = 0
-    agent_picker = Configuration.agent_picker_class(targets)
+    agent_picker = Configuration.agent_picker_class(qclient, targets)
     for router_id in router_id_list:
         target = agent_picker.pick()
         if migrate_router_safely(qclient, noop, router_id, agent,
@@ -918,7 +921,7 @@ def list_dead_agents(agent_list, agent_type):
 
 
 class RandomAgentPicker(object):
-    def __init__(self, agents):
+    def __init__(self, qclient, agents):
         self.agents = agents
 
     def pick(self):
@@ -965,7 +968,7 @@ class Configuration(object):
     Registry for storing application's configuration
     """
 
-    agent_picker_class = RandomAgentPicker
+    agent_picker_class = LeastBusyAgentPicker
 
 
 if __name__ == '__main__':

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -244,15 +244,7 @@ def run(args):
     # set json return type
     qclient.format = 'json'
 
-    if args.agent_selection_mode == 'random':
-        Configuration.agent_picker = RandomAgentPicker()
-    elif args.agent_selection_mode == 'least-busy':
-        Configuration.agent_picker = LeastBusyAgentPicker(qclient)
-    else:
-        raise ValueError('Invalid agent_selection_mode')
-
-    if args.target_agent is not None:
-        Configuration.agent_picker = SingleAgentPicker(args.target_agent)
+    configure(args, qclient)
 
     if args.l3_agent_check:
         LOG.info("Performing L3 Agent Health Check")
@@ -1011,6 +1003,18 @@ class Configuration(object):
     """
 
     agent_picker = RandomAgentPicker()
+
+
+def configure(args, qclient):
+    if args.agent_selection_mode == 'random':
+        Configuration.agent_picker = RandomAgentPicker()
+    elif args.agent_selection_mode == 'least-busy':
+        Configuration.agent_picker = LeastBusyAgentPicker(qclient)
+    else:
+        raise ValueError('Invalid agent_selection_mode')
+
+    if args.target_agent is not None:
+        Configuration.agent_picker = SingleAgentPicker(args.target_agent)
 
 
 if __name__ == '__main__':

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -112,6 +112,9 @@ def parse_args():
                     help='Determines how target agent is selected for routers '
                          '"random" selects target agent randomly, '
                          '"least-busy" selects the least busy agent.')
+    ap.add_argument('--target-agent', default=None,
+                    help='Explicitly select a target agent either by specifying '
+                         'an agent id or a host id.')
     wait_parser = ap.add_mutually_exclusive_group(required=False)
     wait_parser.add_argument('--wait-for-router', action='store_true',
                              dest='wait_for_router')
@@ -242,6 +245,10 @@ def run(args):
         Configuration.agent_picker_class = LeastBusyAgentPicker
     else:
         raise ValueError('Invalid agent_selection_mode')
+
+    if args.target_agent is not None:
+        Configuration.agent_picker_class = SingleAgentPicker
+        SingleAgentPicker.agent_selection_value = args.target_agent
 
     if args.l3_agent_check:
         LOG.info("Performing L3 Agent Health Check")

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -568,6 +568,7 @@ def migrate_l3_routers_from_agent(qclient, agent, targets,
                                   noop, wait_for_router, delete_namespace):
     LOG.info("Querying agent_id=%s for routers to migrate away", agent['id'])
     router_id_list = list_routers_on_l3_agent(qclient, agent['id'])
+    router_id_list = Configuration.router_filter.filter_routers(router_id_list)
 
     migrations = 0
     errors = 0
@@ -997,12 +998,18 @@ class SingleAgentPicker(object):
         return self.find_agent(self.agent_selection_value)
 
 
+class NullRouterFilter(object):
+    def filter_routers(self, router_id_list):
+        return router_id_list
+
+
 class Configuration(object):
     """
     Registry for storing application's configuration
     """
 
     agent_picker = RandomAgentPicker()
+    router_filter = NullRouterFilter()
 
 
 def configure(args, qclient):

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -106,12 +106,12 @@ def parse_args():
                          'some reason.')
     wait_parser = ap.add_mutually_exclusive_group(required=False)
     wait_parser.add_argument('--wait-for-router', action='store_true',
-                    dest='wait_for_router')
+                             dest='wait_for_router')
     wait_parser.add_argument('--no-wait-for-router', action='store_false',
-                    dest='wait_for_router',
-                    help='When migrating routers, do not wait for its ports and '
-                         'floating IPs to be ACTIVE again on the target '
-                         'agent.')
+                             dest='wait_for_router',
+                             help='When migrating routers, do not wait for '
+                                  'its ports and floating IPs to be ACTIVE '
+                                  'again on the target agent.')
     wait_parser.set_defaults(wait_for_router=True)
     args = ap.parse_args()
     modes = [
@@ -307,8 +307,8 @@ def l3_agent_rebalance(qclient, noop=False, wait_for_router=True):
         routers_on_l3_agent_dict[l3_agent['id']] = \
             list_routers_on_l3_agent(qclient, l3_agent['id'])
 
-    ordered_l3_agent_dict = OrderedDict(sorted(routers_on_l3_agent_dict.items(),
-                                               key=lambda t: len(t[0])))
+    ordered_l3_agent_dict = OrderedDict(
+        sorted(routers_on_l3_agent_dict.items(), key=lambda t: len(t[0])))
     ordered_l3_agent_list = list(ordered_l3_agent_dict)
     num_agents = len(ordered_l3_agent_list)
     LOG.info("Agent list: %s",
@@ -764,7 +764,7 @@ def list_routers(qclient):
     resp = qclient.list_routers()
     LOG.debug("list_routers: %s", resp)
     # Filter routers to not include HA routers
-    return [i for i in resp['routers'] if not i.get('ha') == True]
+    return [i for i in resp['routers'] if not i.get('ha') == True]  # noqa
 
 
 def list_routers_on_l3_agent(qclient, agent_id):
@@ -776,7 +776,7 @@ def list_routers_on_l3_agent(qclient, agent_id):
 
     resp = qclient.list_routers_on_l3_agent(agent_id)
     LOG.debug("list_routers_on_l3_agent: %s", resp)
-    return [r['id'] for r in resp['routers'] if not r.get('ha') == True]
+    return [r['id'] for r in resp['routers'] if not r.get('ha') == True]  # noqa
 
 
 def list_agents(qclient, agent_type=None):

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -411,7 +411,8 @@ def l3_agent_migrate(qclient, noop=False, now=False,
     """
     Walk the l3 agents searching for agents that are offline.  For those that
     are offline, we will retrieve a list of routers on them and migrate them to
-    a random l3 agent that is online.
+    an l3 agent that is online using the strategy specified by
+    Configuration.agent_picker_class.
 
     :param qclient: A neutronclient
     :param noop: Optional noop flag

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -942,7 +942,6 @@ class RandomAgentPicker(object):
 
 class LeastBusyAgentPicker(object):
     def __init__(self, qclient):
-        self.now = datetime.datetime.now
         self.cache_created_at = None
         self.qclient = qclient
         self.agents_by_id = {}
@@ -959,10 +958,10 @@ class LeastBusyAgentPicker(object):
             self.router_count_per_agent_id[agent_id] = len(
                 list_routers_on_l3_agent(self.qclient, agent_id)
             )
-        self.cache_created_at = self.now()
+        self.cache_created_at = datetime.datetime.now()
 
     def cache_expired(self):
-        cache_life = self.now() - self.cache_created_at
+        cache_life = datetime.datetime.now() - self.cache_created_at
         return cache_life.total_seconds() > ROUTER_CACHE_MAX_AGE_SECONDS
 
     def pick(self):

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -57,16 +57,7 @@ IDENTITY_API_VERSIONS = {
 ROUTER_CACHE_MAX_AGE_SECONDS = 5 * 60
 
 
-def parse_args():
-    # ensure environment has necessary items to authenticate
-    for key in ['OS_USERNAME', 'OS_AUTH_URL', 'OS_REGION_NAME']:
-        if key not in os.environ.keys():
-            raise SystemExit("Your environment is missing '%s'" % key)
-    keys = ['OS_TENANT_NAME', 'OS_PROJECT_NAME']
-    if not any(key in os.environ.keys() for key in keys):
-        raise SystemExit("Your environment is missing "
-                         "'OS_TENANT_NAME' or 'OS_PROJECT_NAME")
-
+def make_argparser():
     ap = argparse.ArgumentParser(description=DESCRIPTION)
     ap.add_argument('-d', '--debug', action='store_true',
                     default=False, help='Show debugging output')
@@ -124,6 +115,20 @@ def parse_args():
                                   'its ports and floating IPs to be ACTIVE '
                                   'again on the target agent.')
     wait_parser.set_defaults(wait_for_router=True)
+    return ap
+
+
+def parse_args():
+    # ensure environment has necessary items to authenticate
+    for key in ['OS_USERNAME', 'OS_AUTH_URL', 'OS_REGION_NAME']:
+        if key not in os.environ.keys():
+            raise SystemExit("Your environment is missing '%s'" % key)
+    keys = ['OS_TENANT_NAME', 'OS_PROJECT_NAME']
+    if not any(key in os.environ.keys() for key in keys):
+        raise SystemExit("Your environment is missing "
+                         "'OS_TENANT_NAME' or 'OS_PROJECT_NAME")
+
+    ap = make_argparser()
     args = ap.parse_args()
     modes = [
         args.l3_agent_check,

--- a/files/default/test-neutron-ha-tool.py
+++ b/files/default/test-neutron-ha-tool.py
@@ -336,6 +336,16 @@ class TestMakeConfiguration(unittest.TestCase):
         )
 
 
+class TestRouterFilterConfiguration(unittest.TestCase):
+    def test_null_router_filter_is_the_default(self):
+        configure_with('')
+
+        self.assertIsInstance(
+            ha_tool.Configuration.router_filter,
+            ha_tool.NullRouterFilter
+        )
+
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)
     unittest.main()

--- a/files/default/test-neutron-ha-tool.py
+++ b/files/default/test-neutron-ha-tool.py
@@ -152,13 +152,14 @@ class TestLeastBusyAgentPicker(unittest.TestCase):
         self.neutron_client = neutron_client
 
     def make_picker(self):
-        return ha_tool.LeastBusyAgentPicker(
-            self.neutron_client,
+        picker = ha_tool.LeastBusyAgentPicker(self.neutron_client)
+        picker.set_agents(
             [
                 {'id': 'live-agent-0'},
                 {'id': 'live-agent-1'}
             ]
         )
+        return picker
 
     def test_initial_numbers_queried(self):
         self.neutron_client.tst_add_router('live-agent-0', 'router', {})
@@ -232,7 +233,8 @@ class TestLeastBusyAgentPicker(unittest.TestCase):
         self.assertEqual('live-agent-1', picker.pick()['id'])
 
     def test_pick_on_empty_array_throws_index_error_as_random_does(self):
-        picker = ha_tool.LeastBusyAgentPicker(self.neutron_client, [])
+        picker = ha_tool.LeastBusyAgentPicker(self.neutron_client)
+        picker.set_agents([])
 
         with self.assertRaises(IndexError):
             picker.pick()
@@ -245,8 +247,8 @@ class TestSingleAgentPicker(unittest.TestCase):
         self.neutron_client = neutron_client
 
     def make_picker(self):
-        picker = ha_tool.SingleAgentPicker(
-            self.neutron_client,
+        picker = ha_tool.SingleAgentPicker(None)
+        picker.set_agents(
             [
                 {'id': 'live-agent-0', 'host': 'host-0'},
                 {'id': 'live-agent-1', 'host': 'host-1'}
@@ -283,10 +285,8 @@ class TestSingleAgentPicker(unittest.TestCase):
         self.assertEqual('Cannot find desired agent', str(ctx.exception))
 
     def test_agent_selection_value_not_specified_raises_value_error(self):
-        picker = ha_tool.SingleAgentPicker(
-            self.neutron_client,
-            []
-        )
+        picker = ha_tool.SingleAgentPicker(None)
+        picker.set_agents([])
 
         self.assertRaises(ValueError, picker.pick)
 

--- a/files/default/test-neutron-ha-tool.py
+++ b/files/default/test-neutron-ha-tool.py
@@ -1,0 +1,149 @@
+import unittest
+import collections
+import importlib
+import logging
+ha_tool = importlib.import_module("neutron-ha-tool")
+
+
+class MockNeutronClient(object):
+
+    def __init__(self):
+        self.routers = {}
+        self.agents = {}
+        self.routers_by_agent = collections.defaultdict(set)
+
+    def tst_add_agent(self, agent_id, props):
+        self.agents[agent_id] = dict(props, id=agent_id)
+
+    def tst_add_router(self, agent_id, router_id, props):
+        self.routers[router_id] = dict(props, id=router_id)
+        self.routers_by_agent[agent_id].add(router_id)
+
+    def tst_agent_by_router(self, router_id):
+        for agent_id, router_ids in self.routers_by_agent.items():
+            if router_id in router_ids:
+                return self.agents[agent_id]
+
+        raise NotImplementedError()
+
+    def list_agents(self):
+        return {
+            'agents': self.agents.values()
+        }
+
+    def list_routers_on_l3_agent(self, agent_id):
+        return {
+            'routers': [
+                self.routers[router_id]
+                for router_id in self.routers_by_agent[agent_id]
+            ]
+        }
+
+    def remove_router_from_l3_agent(self, agent_id, router_id):
+        self.routers_by_agent[agent_id].remove(router_id)
+
+    def add_router_to_l3_agent(self, agent_id, router_body):
+        self.routers_by_agent[agent_id].add(router_body['router_id'])
+
+    def list_ports(self, device_id, fields):
+        return {
+            'ports': [
+                {
+                    'id': 'someid',
+                    'binding:host_id':
+                        self.tst_agent_by_router(device_id)['host'],
+                    'binding:vif_type': 'non distributed',
+                    'status': 'ACTIVE'
+                }
+            ]
+        }
+
+    def list_floatingips(self, router_id):
+        return {
+            'floatingips': [
+                {
+                    'id': 'irrelevant',
+                    'status': 'ACTIVE'
+                }
+            ]
+        }
+
+
+def make_neturon_client(live_agents=0, dead_agents=0):
+    neutron_client = MockNeutronClient()
+
+    for i in range(live_agents):
+        neutron_client.tst_add_agent(
+            'live-agent-{}'.format(i), {
+                'agent_type': 'L3 agent',
+                'alive': True,
+                'admin_state_up': True,
+                'host': 'live-agent-{}-host'.format(i),
+                'configurations': {
+                    'agent_mode': 'Mode X'
+                }
+            }
+        )
+    for i in range(dead_agents):
+        neutron_client.tst_add_agent(
+            'dead-agent-{}'.format(i), {
+                'agent_type': 'L3 agent',
+                'alive': False,
+                'admin_state_up': False,
+                'host': 'dead-agent-{}-host'.format(i)
+            }
+        )
+    return neutron_client
+
+
+class TestL3AgentMigrate(unittest.TestCase):
+
+    def test_no_dead_agents_returns_zero(self):
+        neutron_client = make_neturon_client(live_agents=2)
+
+        result = ha_tool.l3_agent_migrate(neutron_client)
+
+        self.assertEqual(0, result)
+
+    def test_no_alive_agents_returns_one(self):
+        neutron_client = make_neturon_client(dead_agents=2)
+
+        result = ha_tool.l3_agent_migrate(neutron_client)
+
+        self.assertEqual(1, result)
+
+    def test_router_moved(self):
+        neutron_client = make_neturon_client(live_agents=1, dead_agents=1)
+        neutron_client.tst_add_router('dead-agent-0', 'router-1', {})
+
+        result = ha_tool.l3_agent_migrate(neutron_client, now=True)
+
+        self.assertEqual(0, result)
+        self.assertEqual(
+            set(['router-1']), neutron_client.routers_by_agent['live-agent-0'])
+
+
+class TestL3AgentEvacuate(unittest.TestCase):
+
+    def test_no_agents_returns_zero(self):
+        neutron_client = MockNeutronClient()
+        result = ha_tool.l3_agent_evacuate(neutron_client, 'host1')
+
+        self.assertEqual(0, result)
+
+    def test_evacuation(self):
+        neutron_client = make_neturon_client(live_agents=2)
+        neutron_client.tst_add_router('live-agent-0', 'router', {})
+
+        result = ha_tool.l3_agent_evacuate(neutron_client, 'live-agent-0-host')
+
+        self.assertEqual(0, result)
+        self.assertEqual(
+            set(['router']),
+            neutron_client.routers_by_agent['live-agent-1']
+        )
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.DEBUG)
+    unittest.main()

--- a/files/default/test-requirements.txt
+++ b/files/default/test-requirements.txt
@@ -1,0 +1,6 @@
+coverage
+flake8
+
+retrying
+python-neutronclient
+python-keystoneclient


### PR DESCRIPTION
Enable users to specify a path that points to a file with one router per line. Only routers that are listed in the file will be moved. Please note that it might mean that an agent won't be fully evacuated, if there are routers that are hosted by the agent, but not specified in the router list file.

Please note that this is on top of PR #10 

Please start your review with the commit named: "refactor - inline now"