### PR TITLE
Refactor: eliminate global variable, amend agent picker interface

### DIFF
--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -411,7 +411,7 @@ def l3_agent_migrate(qclient, agent_picker, noop=False, now=False,
     """
     Walk the l3 agents searching for agents that are offline.  For those that
     are offline, we will retrieve a list of routers on them and migrate them to
-    a random l3 agent that is online.
+    an l3 agent that is online.
 
     :param qclient: A neutronclient
     :param noop: Optional noop flag

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -237,9 +237,9 @@ def run(args):
     qclient.format = 'json'
 
     if args.agent_selection_mode == 'random':
-        Configuration.agent_picker_class = RandomAgentPicker
+        agent_picker_class = RandomAgentPicker
     elif args.agent_selection_mode == 'least-busy':
-        Configuration.agent_picker_class = LeastBusyAgentPicker
+        agent_picker_class = LeastBusyAgentPicker
     else:
         raise ValueError('Invalid agent_selection_mode')
 
@@ -253,14 +253,14 @@ def run(args):
     elif args.l3_agent_migrate:
         LOG.info("Performing L3 Agent Migration for Offline L3 Agents")
         errors = retry_with_backoff(l3_agent_migrate, args)(
-            qclient, args.noop, args.now, args.wait_for_router,
-            args.ssh_delete_namespace)
+            qclient, agent_picker_class, args.noop, args.now,
+            args.wait_for_router, args.ssh_delete_namespace)
 
     elif args.l3_agent_evacuate:
         LOG.info("Performing L3 Agent Evacuation from host %s",
                  args.l3_agent_evacuate)
         errors = retry_with_backoff(l3_agent_evacuate, args)(
-            qclient, args.l3_agent_evacuate, args.noop,
+            qclient, args.l3_agent_evacuate, agent_picker_class, args.noop,
             args.wait_for_router, args.ssh_delete_namespace)
 
     elif args.l3_agent_rebalance:
@@ -406,7 +406,7 @@ def l3_agent_check(qclient):
     return migration_count
 
 
-def l3_agent_migrate(qclient, noop=False, now=False,
+def l3_agent_migrate(qclient, agent_picker_class, noop=False, now=False,
                      wait_for_router=True, ssh_delete_namespace=False):
     """
     Walk the l3 agents searching for agents that are offline.  For those that
@@ -459,7 +459,7 @@ def l3_agent_migrate(qclient, noop=False, now=False,
     for agent in agent_dead_list:
         (migrations, errors) = \
             migrate_l3_routers_from_agent(qclient, agent, agent_alive_list,
-                                          noop, wait_for_router,
+                                          agent_picker_class, noop, wait_for_router,
                                           ssh_delete_namespace)
         total_migrations += migrations
         total_errors += errors
@@ -472,7 +472,7 @@ def l3_agent_migrate(qclient, noop=False, now=False,
     return total_errors
 
 
-def l3_agent_evacuate(qclient, agent_host, noop=False,
+def l3_agent_evacuate(qclient, agent_host, agent_picker_class, noop=False,
                       wait_for_router=True, ssh_delete_namespace=False):
     """
     Retreive a list of routers scheduled on the listed agent, and move that
@@ -504,8 +504,8 @@ def l3_agent_evacuate(qclient, agent_host, noop=False,
 
     (migrations, errors) = \
         migrate_l3_routers_from_agent(qclient, agent_to_evacuate,
-                                      target_list, noop, wait_for_router,
-                                      ssh_delete_namespace)
+                                      target_list, agent_picker_class, noop,
+                                      wait_for_router, ssh_delete_namespace)
     LOG.info("%d routers %s evacuated from L3 agent %s", migrations,
              "would have been" if noop else "were", agent_host)
     if errors > 0:
@@ -560,14 +560,14 @@ def replicate_dhcp(qclient, noop=False):
     return errors
 
 
-def migrate_l3_routers_from_agent(qclient, agent, targets,
+def migrate_l3_routers_from_agent(qclient, agent, targets, agent_picker_class,
                                   noop, wait_for_router, delete_namespace):
     LOG.info("Querying agent_id=%s for routers to migrate away", agent['id'])
     router_id_list = list_routers_on_l3_agent(qclient, agent['id'])
 
     migrations = 0
     errors = 0
-    agent_picker = Configuration.agent_picker_class(qclient, targets)
+    agent_picker = agent_picker_class(qclient, targets)
     for router_id in router_id_list:
         target = agent_picker.pick()
         if migrate_router_safely(qclient, noop, router_id, agent,
@@ -960,14 +960,6 @@ class LeastBusyAgentPicker(object):
         agent_id = agent_id_number_of_routers[0][0]
         self.router_count_per_agent_id[agent_id] += 1
         return self.agents_by_id[agent_id]
-
-
-class Configuration(object):
-    """
-    Registry for storing application's configuration
-    """
-
-    agent_picker_class = LeastBusyAgentPicker
 
 
 if __name__ == '__main__':

--- a/files/default/test-neutron-ha-tool.py
+++ b/files/default/test-neutron-ha-tool.py
@@ -122,7 +122,7 @@ class TestL3AgentMigrate(unittest.TestCase):
         neutron_client.tst_add_router('dead-agent-0', 'router-1', {})
 
         result = ha_tool.l3_agent_migrate(
-            neutron_client, ha_tool.RandomAgentPicker, now=True)
+            neutron_client, ha_tool.RandomAgentPicker(), now=True)
 
         self.assertEqual(0, result)
         self.assertEqual(
@@ -145,7 +145,7 @@ class TestL3AgentEvacuate(unittest.TestCase):
         neutron_client.tst_add_router('live-agent-0', 'router', {})
 
         result = ha_tool.l3_agent_evacuate(
-            neutron_client, 'live-agent-0-host', ha_tool.RandomAgentPicker)
+            neutron_client, 'live-agent-0-host', ha_tool.RandomAgentPicker())
 
         self.assertEqual(0, result)
         self.assertEqual(
@@ -161,13 +161,14 @@ class TestLeastBusyAgentPicker(unittest.TestCase):
         self.neutron_client = neutron_client
 
     def make_picker(self):
-        return ha_tool.LeastBusyAgentPicker(
-            self.neutron_client,
+        picker = ha_tool.LeastBusyAgentPicker(self.neutron_client)
+        picker.set_agents(
             [
                 {'id': 'live-agent-0'},
                 {'id': 'live-agent-1'}
             ]
         )
+        return picker
 
     def test_initial_numbers_queried(self):
         self.neutron_client.tst_add_router('live-agent-0', 'router', {})
@@ -241,7 +242,8 @@ class TestLeastBusyAgentPicker(unittest.TestCase):
         self.assertEqual('live-agent-1', picker.pick()['id'])
 
     def test_pick_on_empty_array_throws_index_error_as_random_does(self):
-        picker = ha_tool.LeastBusyAgentPicker(self.neutron_client, [])
+        picker = ha_tool.LeastBusyAgentPicker(self.neutron_client)
+        picker.set_agents([])
 
         with self.assertRaises(IndexError):
             picker.pick()

--- a/files/default/test-neutron-ha-tool.py
+++ b/files/default/test-neutron-ha-tool.py
@@ -102,14 +102,18 @@ class TestL3AgentMigrate(unittest.TestCase):
     def test_no_dead_agents_returns_zero(self):
         neutron_client = make_neturon_client(live_agents=2)
 
-        result = ha_tool.l3_agent_migrate(neutron_client)
+        # None as Agent Picker - given no dead agents, no migration, and
+        # therefore no agent picking will take place
+        result = ha_tool.l3_agent_migrate(neutron_client, None)
 
         self.assertEqual(0, result)
 
     def test_no_alive_agents_returns_one(self):
         neutron_client = make_neturon_client(dead_agents=2)
 
-        result = ha_tool.l3_agent_migrate(neutron_client)
+        # None as Agent Picker - given no live agents, no migration, and
+        # therefore no agent picking will take place
+        result = ha_tool.l3_agent_migrate(neutron_client, None)
 
         self.assertEqual(1, result)
 
@@ -117,7 +121,8 @@ class TestL3AgentMigrate(unittest.TestCase):
         neutron_client = make_neturon_client(live_agents=1, dead_agents=1)
         neutron_client.tst_add_router('dead-agent-0', 'router-1', {})
 
-        result = ha_tool.l3_agent_migrate(neutron_client, now=True)
+        result = ha_tool.l3_agent_migrate(
+            neutron_client, ha_tool.RandomAgentPicker, now=True)
 
         self.assertEqual(0, result)
         self.assertEqual(
@@ -128,7 +133,10 @@ class TestL3AgentEvacuate(unittest.TestCase):
 
     def test_no_agents_returns_zero(self):
         neutron_client = MockNeutronClient()
-        result = ha_tool.l3_agent_evacuate(neutron_client, 'host1')
+
+        # None as Agent Picker - given no agents, no migration, and therefore no
+        # agent picking will take place
+        result = ha_tool.l3_agent_evacuate(neutron_client, 'host1', None)
 
         self.assertEqual(0, result)
 
@@ -136,7 +144,8 @@ class TestL3AgentEvacuate(unittest.TestCase):
         neutron_client = make_neturon_client(live_agents=2)
         neutron_client.tst_add_router('live-agent-0', 'router', {})
 
-        result = ha_tool.l3_agent_evacuate(neutron_client, 'live-agent-0-host')
+        result = ha_tool.l3_agent_evacuate(
+            neutron_client, 'live-agent-0-host', ha_tool.RandomAgentPicker)
 
         self.assertEqual(0, result)
         self.assertEqual(

--- a/files/default/test-neutron-ha-tool.py
+++ b/files/default/test-neutron-ha-tool.py
@@ -70,7 +70,7 @@ class MockNeutronClient(object):
         }
 
 
-def make_neturon_client(live_agents=0, dead_agents=0):
+def make_neutron_client(live_agents=0, dead_agents=0):
     neutron_client = MockNeutronClient()
 
     for i in range(live_agents):
@@ -100,7 +100,7 @@ def make_neturon_client(live_agents=0, dead_agents=0):
 class TestL3AgentMigrate(unittest.TestCase):
 
     def test_no_dead_agents_returns_zero(self):
-        neutron_client = make_neturon_client(live_agents=2)
+        neutron_client = make_neutron_client(live_agents=2)
 
         # None as Agent Picker - given no dead agents, no migration, and
         # therefore no agent picking will take place
@@ -109,7 +109,7 @@ class TestL3AgentMigrate(unittest.TestCase):
         self.assertEqual(0, result)
 
     def test_no_alive_agents_returns_one(self):
-        neutron_client = make_neturon_client(dead_agents=2)
+        neutron_client = make_neutron_client(dead_agents=2)
 
         # None as Agent Picker - given no live agents, no migration, and
         # therefore no agent picking will take place
@@ -118,7 +118,7 @@ class TestL3AgentMigrate(unittest.TestCase):
         self.assertEqual(1, result)
 
     def test_router_moved(self):
-        neutron_client = make_neturon_client(live_agents=1, dead_agents=1)
+        neutron_client = make_neutron_client(live_agents=1, dead_agents=1)
         neutron_client.tst_add_router('dead-agent-0', 'router-1', {})
 
         result = ha_tool.l3_agent_migrate(
@@ -141,7 +141,7 @@ class TestL3AgentEvacuate(unittest.TestCase):
         self.assertEqual(0, result)
 
     def test_evacuation(self):
-        neutron_client = make_neturon_client(live_agents=2)
+        neutron_client = make_neutron_client(live_agents=2)
         neutron_client.tst_add_router('live-agent-0', 'router', {})
 
         result = ha_tool.l3_agent_evacuate(
@@ -157,7 +157,7 @@ class TestL3AgentEvacuate(unittest.TestCase):
 class TestLeastBusyAgentPicker(unittest.TestCase):
 
     def setUp(self):
-        neutron_client = make_neturon_client(live_agents=2)
+        neutron_client = make_neutron_client(live_agents=2)
         self.neutron_client = neutron_client
 
     def make_picker(self):


### PR DESCRIPTION
This change eliminates the code smell of having a global Configuration variable, and also passes around agent picker instances instead of classes - this way clients are no longer responsible for providing dependencies for the agent pickers.