### PR TITLE
Fix agent re-balancing (bsc#1029297)

### DIFF
--- a/files/default/test-neutron-ha-tool.py
+++ b/files/default/test-neutron-ha-tool.py
@@ -640,6 +640,36 @@ class TestAgentRebalancing(unittest.TestCase):
             [53, 53, 53, 53, 52], get_router_distribution(neutron_client)
         )
 
+    def test_no_agents_in_the_system(self):
+        fake_neutron = fake_neutron_with_distribution([])
+        neutron_client = FakeNeutronClient(fake_neutron)
+
+        ha_tool.l3_agent_rebalance(neutron_client)
+
+        self.assertEqual(
+            [], get_router_distribution(neutron_client)
+        )
+
+    def test_already_balanced_system_is_not_touched(self):
+        fake_neutron = fake_neutron_with_distribution([5, 4, 5, 4, 5])
+        neutron_client = FakeNeutronClient(fake_neutron)
+
+        ha_tool.l3_agent_rebalance(neutron_client)
+
+        self.assertEqual(
+            [5, 4, 5, 4, 5], get_router_distribution(neutron_client)
+        )
+
+    def test_only_one_agent_exists(self):
+        fake_neutron = fake_neutron_with_distribution([5])
+        neutron_client = FakeNeutronClient(fake_neutron)
+
+        ha_tool.l3_agent_rebalance(neutron_client)
+
+        self.assertEqual(
+            [5], get_router_distribution(neutron_client)
+        )
+
 
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)

--- a/files/default/test-neutron-ha-tool.py
+++ b/files/default/test-neutron-ha-tool.py
@@ -607,6 +607,40 @@ class TestTermDisabled(SignalHandlerTest):
         self.assertFalse(ha_tool.SHOULD_NOT_TERMINATE)
 
 
+def get_router_distribution(neutron_client):
+    agents = neutron_client.list_agents()['agents']
+    agent_ids = sorted([agent['id'] for agent in agents])
+    return [
+        len(neutron_client.list_routers_on_l3_agent(agent_id)['routers'])
+        for agent_id in agent_ids
+    ]
+
+
+def fake_neutron_with_distribution(router_distribution):
+    fake_neutron = setup_fake_neutron(live_agents=len(router_distribution))
+    router_id = 0
+    for agent_serial, num_routers in enumerate(router_distribution):
+        agent_id = 'live-agent-{}'.format(agent_serial)
+        for i in range(num_routers):
+            fake_neutron.add_router(
+                agent_id, 'router-{}'.format(router_id), {}
+            )
+            router_id += 1
+    return fake_neutron
+
+
+class TestAgentRebalancing(unittest.TestCase):
+    def test_balancing_scenario(self):
+        fake_neutron = fake_neutron_with_distribution([66, 67, 67, 64, 0])
+        neutron_client = FakeNeutronClient(fake_neutron)
+
+        ha_tool.l3_agent_rebalance(neutron_client)
+
+        self.assertEqual(
+            [53, 53, 53, 53, 52], get_router_distribution(neutron_client)
+        )
+
+
 if __name__ == "__main__":
     logging.basicConfig(level=logging.DEBUG)
     unittest.main()


### PR DESCRIPTION
The original implementation was broken, and did not rebalance the number
of routers between agents. This new implementation provides a
deterministic way to re-balance the routers between agents.