### PR TITLE
add tool to evacuate LBaaSv2 loadbalancers from a node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
 install:
     - pip install -r files/default/test-requirements.txt
 script:
-    - flake8 neutron-ha-tool.py test-neutron-ha-tool.py
+    - flake8 neutron-ha-tool.py test-neutron-ha-tool.py 
+    - flake8 neutron-evacuate-lbaasv2-agent.py test-neutron-evacuate-lbaasv2-agent.py
     - python files/default/test-neutron-ha-tool.py
+    - python files/default/test-neutron-evacuate-lbaasv2-agent.py
 

--- a/files/default/neutron-evacuate-lbaasv2-agent.py
+++ b/files/default/neutron-evacuate-lbaasv2-agent.py
@@ -1,0 +1,234 @@
+#!/usr/bin/python
+#
+# Copyright 2017, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import importlib
+import socket
+import sqlalchemy
+import sys
+from oslo_utils import timeutils
+from oslo_config import cfg
+from oslo_log import log as logging
+
+LOG = logging.getLogger(__name__)
+
+# Try to fall back loading the neutron-ha-tool from an absolute path.
+# As on the installed system we're installing neutron-ha-tool without
+# the ".py" extension, which causes importlib.import_module to fail.
+try:
+    hatool = importlib.import_module("neutron-ha-tool")
+except ImportError:
+    import imp
+    import os
+    dirname = os.path.dirname(os.path.abspath(__file__))
+    hatool = imp.load_source(
+        '', os.path.join(dirname, '/usr/bin/neutron-ha-tool'))
+
+
+
+class EvacuateLbaasV2Agent(object):
+
+    def __init__(self):
+        _default_opts = [
+            cfg.StrOpt('host',
+                       required=True,
+                       help='name of the host to evacuate'),
+            cfg.IntOpt('agent_down_time', default=75),
+            cfg.BoolOpt('use_crm',
+                        default=False,
+                        help='When restarting an agent, assume a pacemaker '
+                        'setup and use crm to switch the node into '
+                        'maintenance mode before restarting the agent.'),
+            cfg.BoolOpt('source_agent_restart',
+                        default=True,
+                        help='Restart the neutron-lbaasv2-agent '
+                        'on the node that is being evacuated.'),
+            cfg.BoolOpt('delete_namespaces',
+                        default=False,
+                        help='After evacuating an agent, ssh to it, '
+                        'delete all related loadbalancer namespaces and '
+                        'terminate all processes still running in those '
+                        'namespaces.')
+        ]
+
+        _db_opts = [
+            cfg.StrOpt('connection',
+                       deprecated_name='sql_connection',
+                       default='',
+                       secret=True,
+                       help='URL to database'),
+        ]
+
+        cfg.CONF.register_cli_opts(_db_opts, 'database')
+        cfg.CONF.register_cli_opts(_default_opts)
+        logging.register_options(cfg.CONF)
+        logging.set_defaults()
+
+        self.host_to_evacuate = ""
+
+    # Find all possible destination agents for our migration. Ignore
+    # agent that have set admin_state_down or did not send  their
+    # heartbeat recently
+    def available_destination_agents(self):
+        ret = self.connection.execute(
+            "SELECT id,host,heartbeat_timestamp "
+            "FROM agents WHERE "
+            "agents.host != %s "
+            "AND agents.binary='neutron-lbaasv2-agent' "
+            "AND agents.admin_state_up=true;",
+            self.host_to_evacuate)
+
+        return [{'id': id, 'host': host}
+                for id, host, timestamp in ret.fetchall()
+                if not timeutils.is_older_than(timestamp,
+                                               cfg.CONF.agent_down_time)]
+
+    def loadbalancers_on_agent(self, agent_hostname):
+        ret = self.connection.execute(
+            "SELECT loadbalancer_id "
+            "FROM lbaas_loadbalanceragentbindings,agents "
+            "WHERE agents.host = %s "
+            "AND agents.binary='neutron-lbaasv2-agent' "
+            "AND agents.id=lbaas_loadbalanceragentbindings.agent_id;",
+            agent_hostname)
+        return [id[0] for id in ret.fetchall()]
+
+    def reassign_loadbalancers(self, load_balancer_ids, target_agents):
+        for agent in target_agents:
+            agent['load'] = len(self.loadbalancers_on_agent(agent['host']))
+
+        agents_to_restart = set()
+        for loadbalancer in load_balancer_ids:
+            agent = min(target_agents, key=lambda x: x['load'])
+            LOG.info("Reassigning loadbalancer %s to agent %s" %
+                     (loadbalancer, agent))
+
+            self.connection.execute(
+                "UPDATE lbaas_loadbalanceragentbindings "
+                "SET agent_id = %s "
+                "WHERE loadbalancer_id = %s;",
+                agent['id'], loadbalancer
+            )
+            agents_to_restart.add(agent['host'])
+            agent['load'] = agent['load'] + 1
+        return agents_to_restart
+
+    def setup(self):
+        cfg.CONF(project='neutron')
+        # Always log to stderr, ignore setting in neutron.conf
+        cfg.CONF.set_override("use_stderr", True)
+        logging.setup(cfg.CONF, "neutron")
+        self.host_to_evacuate = cfg.CONF.host
+
+        db_uri = cfg.CONF.database.connection
+        db = sqlalchemy.create_engine(db_uri)
+        try:
+            self.connection = db.connect()
+        except sqlalchemy.exc.SQLAlchemyError as e:
+            LOG.error('Cannot connect to database: %s' % e)
+            raise
+
+    def run(self):
+        load_balancers = self.loadbalancers_on_agent(self.host_to_evacuate)
+        if load_balancers:
+            LOG.info("Evacuating loadbalancers: %s", load_balancers)
+            target_agents = self.available_destination_agents()
+
+            if not target_agents:
+                LOG.error("No agents available as a destination for "
+                          "the loadbalancer evacuation.")
+                return(1)
+
+            LOG.info("Available destination agents %s", target_agents)
+            agents_to_restart = list(
+                self.reassign_loadbalancers(load_balancers, target_agents)
+            )
+
+            if (cfg.CONF.source_agent_restart or
+                cfg.CONF.delete_namespaces):
+                # Make sure the source agent is handled first
+                agents_to_restart.insert(0, self.host_to_evacuate)
+
+            LOG.info("agents to restart: %s" % agents_to_restart)
+
+            for host in agents_to_restart:
+                LOG.info("restarting agent on %s" % host)
+                cleanup = RemoteLbaasV2Cleanup(host, timeout=30)
+                if (host != self.host_to_evacuate or
+                    cfg.CONF.source_agent_restart):
+                    if cfg.CONF.use_crm:
+                        cleanup.restart_lbaasv2_agent_crm()
+                    else:
+                        cleanup.restart_lbaasv2_agent_systemd()
+
+                if (host == self.host_to_evacuate and
+                    cfg.CONF.delete_namespaces):
+                    cleanup.delete_lbaasv2_namespaces(load_balancers)
+        else:
+            LOG.info("The agent on %s is not hosting any loadbalancers.",
+                     self.host_to_evacuate)
+        return(0)
+
+
+class RemoteLbaasV2Cleanup(hatool.RemoteNodeCleanup):
+
+    def restart_lbaasv2_agent_crm(self):
+        self._ssh_connect()
+        with self.ssh_client:
+            try:
+                self._simple_ssh_command("crm --wait node maintenance")
+                self._simple_ssh_command(
+                    "systemctl restart openstack-neutron-lbaasv2-agent")
+                self._simple_ssh_command("crm --wait node ready")
+            except socket.timeout:
+                LOG.warn("SSH timeout exceeded. Failed to restart "
+                         "openstack-neutron-lbaasv2-agent on %s",
+                         self.target_host)
+
+    def restart_lbaasv2_agent_systemd(self):
+        self._ssh_connect()
+        with self.ssh_client:
+            try:
+                self._simple_ssh_command(
+                    "systemctl restart openstack-neutron-lbaasv2-agent")
+            except socket.timeout:
+                LOG.warn("SSH timeout exceeded. Failed to restart "
+                         "openstack-neutron-lbaasv2-agent on %s",
+                         self.target_host)
+
+    def delete_lbaasv2_namespaces(self, loadbalancer_ids):
+        self._ssh_connect()
+        with self.ssh_client:
+            for lb in loadbalancer_ids:
+                namespace = "qlbaas-" + lb
+                LOG.info("deleting namespace %s on %s",
+                         namespace, self.target_host)
+                try:
+                    if self._namespace_exists(namespace):
+                        self._kill_pids_in_namespace(namespace)
+                        self._simple_ssh_command(self.netns_del + namespace)
+                except socket.timeout:
+                    LOG.warn("SSH timeout exceeded. Failed to delete "
+                             "namespace %s on %s", namespace,
+                             self.target_host)
+
+
+if __name__ == '__main__':
+    evacuate = EvacuateLbaasV2Agent()
+    evacuate.setup()
+    ret = evacuate.run()
+
+    sys.exit(ret)

--- a/files/default/test-neutron-evacuate-lbaasv2-agent.py
+++ b/files/default/test-neutron-evacuate-lbaasv2-agent.py
@@ -1,0 +1,86 @@
+import unittest
+import importlib
+import mock
+import datetime
+from oslo_utils import timeutils
+
+
+evacuate_lbaas = importlib.import_module("neutron-evacuate-lbaasv2-agent")
+
+
+class FakeSqlResult():
+    def fetchall(self):
+        return [
+            ['1', 'healthy', timeutils.utcnow()],
+            ['2', 'dead', timeutils.utcnow() - datetime.timedelta(seconds=100)]
+        ]
+
+
+class FakeSqlConnection():
+    def execute(self, *args):
+        return FakeSqlResult()
+
+
+class TestEvacuateLbaasV2Agents(unittest.TestCase):
+    def setUp(self):
+        self.evacuate_lbaas = evacuate_lbaas.EvacuateLbaasV2Agent()
+        self.evacuate_lbaas.connection = FakeSqlConnection()
+        self.evacuate_lbaas.host_to_evacuate = "evacuateme"
+
+    def test_available_agents_exclude_dead_agents(self):
+        self.assertEqual(
+            [{'host': 'healthy', 'id': '1'}],
+            self.evacuate_lbaas.available_destination_agents()
+        )
+
+    def test_reassing_single_lb_returns_one_agent(self):
+        agents = [
+            {'host': 'node1', 'id': '1'},
+            {'host': 'node2', 'id': '2'},
+            {'host': 'node3', 'id': '3'}
+        ]
+        loadbalancers = ['abc']
+
+        res = self.evacuate_lbaas.reassign_loadbalancers(loadbalancers, agents)
+        self.assertEqual(1, len(res))
+
+    @mock.patch('neutron-evacuate-lbaasv2-agent.'
+                'EvacuateLbaasV2Agent.loadbalancers_on_agent')
+    @mock.patch('neutron-evacuate-lbaasv2-agent.'
+                'RemoteLbaasV2Cleanup')
+    def test_restarts_agents_using_crm_on_ha(self, mock_cleanup, mock_lbaas):
+        mock_lbaas.return_value = ['lb1']
+        evacuate_lbaas.cfg.CONF.set_override("use_crm", True)
+
+        self.evacuate_lbaas.run()
+        self.assertEqual(
+            mock_cleanup.return_value.restart_lbaasv2_agent_crm.call_count,
+            2
+        )
+        self.assertEqual(
+            mock_cleanup.return_value.restart_lbaasv2_agent_systemd.call_count,
+            0
+        )
+
+    @mock.patch('neutron-evacuate-lbaasv2-agent.'
+                'EvacuateLbaasV2Agent.loadbalancers_on_agent')
+    @mock.patch('neutron-evacuate-lbaasv2-agent.'
+                'RemoteLbaasV2Cleanup')
+    def test_restarts_agents_using_systemd_no_ha(self,
+                                                 mock_cleanup,
+                                                 mock_lbaas):
+        mock_lbaas.return_value = ['lb1']
+        evacuate_lbaas.cfg.CONF.set_override("use_crm", False)
+        self.evacuate_lbaas.run()
+        self.assertEqual(
+            mock_cleanup.return_value.restart_lbaasv2_agent_crm.call_count,
+            0
+        )
+        self.assertEqual(
+            mock_cleanup.return_value.restart_lbaasv2_agent_systemd.call_count,
+            2
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/files/default/test-neutron-ha-tool.py
+++ b/files/default/test-neutron-ha-tool.py
@@ -361,8 +361,8 @@ class TestSshDeleteRouterNamespace(unittest.TestCase):
             return [mock.MagicMock, mock_stdout, mock.MagicMock]
 
         mock_ssh.return_value.exec_command.side_effect = ssh_exec_side_effect
-        ns_cleanup = ha_tool.RemoteRouterNsCleanup("host1", "routerid1")
-        ns_cleanup.delete_router_namespace()
+        ns_cleanup = ha_tool.RemoteRouterNsCleanup("host1")
+        ns_cleanup.delete_router_namespace("routerid1")
         expected_calls = [
             mock.call("ip netns list", get_pty=mock.ANY, timeout=mock.ANY),
             mock.call("ip netns pids qrouter-routerid1", get_pty=mock.ANY,
@@ -388,10 +388,10 @@ class TestSshDeleteRouterNamespace(unittest.TestCase):
                 mock_stdout.readlines.return_value = ["qrouter-otherid\r\n"]
             return [mock.MagicMock(), mock_stdout, mock.MagicMock()]
 
-        ns_cleanup = ha_tool.RemoteRouterNsCleanup("host1", "routerid1")
+        ns_cleanup = ha_tool.RemoteRouterNsCleanup("host1")
         mock_ssh.return_value.exec_command.side_effect = \
             side_effect_namespace_absent
-        ns_cleanup.delete_router_namespace()
+        ns_cleanup.delete_router_namespace("routerid1")
         mock_ssh.return_value.exec_command.assert_called_once_with(
             "ip netns list", timeout=mock.ANY, get_pty=mock.ANY)
 
@@ -402,8 +402,8 @@ class TestSshDeleteRouterNamespace(unittest.TestCase):
 
         mock_ssh.return_value.exec_command.side_effect = \
             side_effect_ssh_connect
-        ns_cleanup = ha_tool.RemoteRouterNsCleanup("host1", "routerid1")
-        ns_cleanup.delete_router_namespace()
+        ns_cleanup = ha_tool.RemoteRouterNsCleanup("host1")
+        ns_cleanup.delete_router_namespace("routerid1")
 
 
 class TestAgentIdBasedAgentPicker(unittest.TestCase):

--- a/files/default/test-requirements.txt
+++ b/files/default/test-requirements.txt
@@ -6,3 +6,7 @@ retrying
 paramiko
 python-neutronclient
 python-keystoneclient
+oslo.utils
+oslo.config
+oslo.log
+SQLAlchemy


### PR DESCRIPTION
The new tool is primary needed for the upgrade case. Where we need to free up nodes before upgrading them. But is might also be useful for other maintenance tasks sometime.

Unfortunately neutron-lbaas doesn't provide API to reassign loadbalancers, so we need to operated on the database directly and force agent restarts.