### PR TITLE
Cleanup after lbaas management script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ python:
 install:
     - pip install -r files/default/test-requirements.txt
 script:
-    - flake8 neutron-ha-tool.py test-neutron-ha-tool.py 
-    - flake8 neutron-evacuate-lbaasv2-agent.py test-neutron-evacuate-lbaasv2-agent.py
-    - python files/default/test-neutron-ha-tool.py
-    - python files/default/test-neutron-evacuate-lbaasv2-agent.py
+    - flake8 *.py
+    - cd files/default && nosetests -v
 

--- a/files/default/README.md
+++ b/files/default/README.md
@@ -6,12 +6,12 @@ Make a python 2 virtual environment, activate it, and install the requirements:
 
 Run the tests
 
-    coverage run test-neutron-ha-tool.py
+    coverage run $(which nosetests) .
 
 Coverage report
 
-    coverage report -i neutron-ha-tool.py
+    coverage report -i $(pwd)/*.py
 
 Code analysis
 
-    flake8 neutron-ha-tool.py test-neutron-ha-tool.py
+    flake8 *.py

--- a/files/default/neutron-evacuate-lbaasv2-agent.py
+++ b/files/default/neutron-evacuate-lbaasv2-agent.py
@@ -38,7 +38,6 @@ except ImportError:
         '', os.path.join(dirname, '/usr/bin/neutron-ha-tool'))
 
 
-
 class EvacuateLbaasV2Agent(object):
 
     def __init__(self):
@@ -157,8 +156,7 @@ class EvacuateLbaasV2Agent(object):
                 self.reassign_loadbalancers(load_balancers, target_agents)
             )
 
-            if (cfg.CONF.source_agent_restart or
-                cfg.CONF.delete_namespaces):
+            if (cfg.CONF.source_agent_restart or cfg.CONF.delete_namespaces):
                 # Make sure the source agent is handled first
                 agents_to_restart.insert(0, self.host_to_evacuate)
 
@@ -167,15 +165,13 @@ class EvacuateLbaasV2Agent(object):
             for host in agents_to_restart:
                 LOG.info("restarting agent on %s" % host)
                 cleanup = RemoteLbaasV2Cleanup(host, timeout=30)
-                if (host != self.host_to_evacuate or
-                    cfg.CONF.source_agent_restart):
+                if (host != self.host_to_evacuate or cfg.CONF.source_agent_restart):  # noqa
                     if cfg.CONF.use_crm:
                         cleanup.restart_lbaasv2_agent_crm()
                     else:
                         cleanup.restart_lbaasv2_agent_systemd()
 
-                if (host == self.host_to_evacuate and
-                    cfg.CONF.delete_namespaces):
+                if (host == self.host_to_evacuate and cfg.CONF.delete_namespaces):  # noqa
                     cleanup.delete_lbaasv2_namespaces(load_balancers)
         else:
             LOG.info("The agent on %s is not hosting any loadbalancers.",

--- a/files/default/neutron-evacuate-lbaasv2-agent.py
+++ b/files/default/neutron-evacuate-lbaasv2-agent.py
@@ -210,16 +210,7 @@ class RemoteLbaasV2Cleanup(hatool.RemoteNodeCleanup):
         with self.ssh_client:
             for lb in loadbalancer_ids:
                 namespace = "qlbaas-" + lb
-                LOG.info("deleting namespace %s on %s",
-                         namespace, self.target_host)
-                try:
-                    if self._namespace_exists(namespace):
-                        self._kill_pids_in_namespace(namespace)
-                        self._simple_ssh_command(self.netns_del + namespace)
-                except socket.timeout:
-                    LOG.warn("SSH timeout exceeded. Failed to delete "
-                             "namespace %s on %s", namespace,
-                             self.target_host)
+                self.delete_remote_namespace(namespace)
 
 
 if __name__ == '__main__':

--- a/files/default/neutron-evacuate-lbaasv2-agent.py
+++ b/files/default/neutron-evacuate-lbaasv2-agent.py
@@ -182,8 +182,7 @@ class EvacuateLbaasV2Agent(object):
 class RemoteLbaasV2Cleanup(hatool.RemoteNodeCleanup):
 
     def restart_lbaasv2_agent_crm(self):
-        self._ssh_connect()
-        with self.ssh_client:
+        with self.connected_to_host():
             try:
                 self._simple_ssh_command("crm --wait node maintenance")
                 self._simple_ssh_command(
@@ -195,8 +194,7 @@ class RemoteLbaasV2Cleanup(hatool.RemoteNodeCleanup):
                          self.target_host)
 
     def restart_lbaasv2_agent_systemd(self):
-        self._ssh_connect()
-        with self.ssh_client:
+        with self.connected_to_host():
             try:
                 self._simple_ssh_command(
                     "systemctl restart openstack-neutron-lbaasv2-agent")
@@ -206,8 +204,7 @@ class RemoteLbaasV2Cleanup(hatool.RemoteNodeCleanup):
                          self.target_host)
 
     def delete_lbaasv2_namespaces(self, loadbalancer_ids):
-        self._ssh_connect()
-        with self.ssh_client:
+        with self.connected_to_host():
             for lb in loadbalancer_ids:
                 namespace = "qlbaas-" + lb
                 self.delete_remote_namespace(namespace)

--- a/files/default/neutron-evacuate-lbaasv2-agent.py
+++ b/files/default/neutron-evacuate-lbaasv2-agent.py
@@ -182,26 +182,26 @@ class EvacuateLbaasV2Agent(object):
 class RemoteLbaasV2Cleanup(hatool.RemoteNodeCleanup):
 
     def restart_lbaasv2_agent_crm(self):
-        with self.connected_to_host():
+        with self.connected_to_host() as host:
             try:
-                self._simple_ssh_command("crm --wait node maintenance")
-                self._simple_ssh_command(
+                host.run("crm --wait node maintenance")
+                host.run(
                     "systemctl restart openstack-neutron-lbaasv2-agent")
-                self._simple_ssh_command("crm --wait node ready")
+                host.run("crm --wait node ready")
             except socket.timeout:
                 LOG.warn("SSH timeout exceeded. Failed to restart "
                          "openstack-neutron-lbaasv2-agent on %s",
-                         self.target_host)
+                         host)
 
     def restart_lbaasv2_agent_systemd(self):
-        with self.connected_to_host():
+        with self.connected_to_host() as host:
             try:
-                self._simple_ssh_command(
+                host.run(
                     "systemctl restart openstack-neutron-lbaasv2-agent")
             except socket.timeout:
                 LOG.warn("SSH timeout exceeded. Failed to restart "
                          "openstack-neutron-lbaasv2-agent on %s",
-                         self.target_host)
+                         host)
 
     def delete_lbaasv2_namespaces(self, loadbalancer_ids):
         with self.connected_to_host():

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -1107,7 +1107,7 @@ class RemoteNodeCleanup(object):
 
     def _kill_pids_in_namespace(self, namespace):
         LOG.debug("Trying to terminate all processes namespace "
-                  "%s on host %s", namespace, self.target_host)
+                  "%s on host %s", namespace, self.host)
         remaining = 3
         pids = self._get_namespace_pids(namespace)
         while pids:
@@ -1126,7 +1126,7 @@ class RemoteNodeCleanup(object):
                         return None
                     else:
                         raise RuntimeError("Failed to kill %s on host %s",
-                                           pid, self.target_host)
+                                           pid, self.host)
 
             remaining -= 1
             if remaining:
@@ -1134,21 +1134,21 @@ class RemoteNodeCleanup(object):
                 if pids:
                     LOG.debug("Some processes are still running in namespace "
                               "%s on host %s. Retrying.", namespace,
-                              self.target_host)
+                              self.host)
                     time.sleep(1)
             else:
                 break
 
     def delete_remote_namespace(self, namespace):
         LOG.info("Deleting namespace %s on host %s.", namespace,
-                 self.target_host)
+                 self.host)
         try:
             if self._namespace_exists(namespace):
                 self._kill_pids_in_namespace(namespace)
                 self.host.run(self.netns_del + namespace)
         except socket.timeout:
             LOG.warn("SSH timeout exceeded. Failed to delete namespace "
-                     "%s on %s", namespace, self.target_host)
+                     "%s on %s", namespace, self.host)
 
 
 class RemoteRouterNsCleanup(RemoteNodeCleanup):

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -719,8 +719,7 @@ def migrate_router(qclient, router, agent, target,
         wait_router_migrated(qclient, router['id'], target['host'])
 
     if delete_namespace:
-        nscleanup = RemoteRouterNsCleanup(agent['host'])
-        nscleanup.delete_router_namespace(router['id'])
+        destroy_router_namespace(agent['host'], router['id'])
 
 
 def wait_router_migrated(qclient, router_id, target_host, maxtries=60):
@@ -1157,6 +1156,11 @@ class RemoteRouterNsCleanup(RemoteNodeCleanup):
         with self.connected_to_host():
             namespace = "qrouter-" + router_id
             self.delete_remote_namespace(namespace)
+
+
+def destroy_router_namespace(hostname, router_id):
+    ns_cleanup = RemoteRouterNsCleanup(hostname)
+    ns_cleanup.delete_router_namespace(router_id)
 
 
 class SSHHost(object):

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -1151,8 +1151,8 @@ class RemoteNodeCleanup(object):
                 break
 
     def delete_remote_namespace(self, namespace):
-        LOG.debug("Deleting namespace %s on host %s.", namespace,
-                  self.target_host)
+        LOG.info("Deleting namespace %s on host %s.", namespace,
+                 self.target_host)
         try:
             if self._namespace_exists(namespace):
                 self._kill_pids_in_namespace(namespace)

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -1153,22 +1153,22 @@ class RemoteNodeCleanup(object):
     def delete_remote_namespace(self, namespace):
         LOG.debug("Deleting namespace %s on host %s.", namespace,
                   self.target_host)
-        self._ssh_connect()
-        with self.ssh_client:
-            try:
-                if self._namespace_exists(namespace):
-                    self._kill_pids_in_namespace(namespace)
-                    self._simple_ssh_command(self.netns_del + namespace)
-            except socket.timeout:
-                LOG.warn("SSH timeout exceeded. Failed to delete namespace "
-                         "%s on %s", namespace, self.target_host)
+        try:
+            if self._namespace_exists(namespace):
+                self._kill_pids_in_namespace(namespace)
+                self._simple_ssh_command(self.netns_del + namespace)
+        except socket.timeout:
+            LOG.warn("SSH timeout exceeded. Failed to delete namespace "
+                     "%s on %s", namespace, self.target_host)
 
 
 class RemoteRouterNsCleanup(RemoteNodeCleanup):
 
     def delete_router_namespace(self, router_id):
-        namespace = "qrouter-" + router_id
-        self.delete_remote_namespace(namespace)
+        self._ssh_connect()
+        with self.ssh_client:
+            namespace = "qrouter-" + router_id
+            self.delete_remote_namespace(namespace)
 
 
 def term_signal_handler(signum, frame):

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -1162,8 +1162,9 @@ class RemoteRouterNsCleanup(RemoteNodeCleanup):
 
 
 class SSHHost(object):
-    def __init__(self, ssh_client):
+    def __init__(self, ssh_client, hostname):
         self._ssh_client = ssh_client
+        self.hostname = hostname
 
     def run(self, command, timeout):
         # Note, that when get_pty is True, paramiko will never return anything
@@ -1176,6 +1177,9 @@ class SSHHost(object):
         rc = stdout.channel.recv_exit_status()
         return [rc, [line.strip() for line in out_lines]]
 
+    def __str__(self):
+        return self.hostname
+
 
 @contextlib.contextmanager
 def connect_to_host(hostname, connect_timeout):
@@ -1185,7 +1189,7 @@ def connect_to_host(hostname, connect_timeout):
         )
         ssh_client.load_system_host_keys()
         ssh_client.connect(hostname, timeout=connect_timeout)
-        yield SSHHost(ssh_client)
+        yield SSHHost(ssh_client, hostname)
 
 
 def term_signal_handler(signum, frame):

--- a/files/default/test-neutron-evacuate-lbaasv2-agent.py
+++ b/files/default/test-neutron-evacuate-lbaasv2-agent.py
@@ -80,7 +80,3 @@ class TestEvacuateLbaasV2Agents(unittest.TestCase):
             mock_cleanup.return_value.restart_lbaasv2_agent_systemd.call_count,
             2
         )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/files/default/test-neutron-evacuate-lbaasv2-agent.py
+++ b/files/default/test-neutron-evacuate-lbaasv2-agent.py
@@ -47,36 +47,36 @@ class TestEvacuateLbaasV2Agents(unittest.TestCase):
     @mock.patch('neutron-evacuate-lbaasv2-agent.'
                 'EvacuateLbaasV2Agent.loadbalancers_on_agent')
     @mock.patch('neutron-evacuate-lbaasv2-agent.'
-                'RemoteLbaasV2Cleanup')
-    def test_restarts_agents_using_crm_on_ha(self, mock_cleanup, mock_lbaas):
+                'restart_lbaasv2_agent_crm')
+    @mock.patch('neutron-evacuate-lbaasv2-agent.'
+                'restart_lbaasv2_agent_systemd')
+    def test_restarts_agents_using_crm_on_ha(self, systemd_cleanup,
+                                             crm_cleanup, mock_lbaas):
         mock_lbaas.return_value = ['lb1']
         evacuate_lbaas.cfg.CONF.set_override("use_crm", True)
 
         self.evacuate_lbaas.run()
-        self.assertEqual(
-            mock_cleanup.return_value.restart_lbaasv2_agent_crm.call_count,
-            2
-        )
-        self.assertEqual(
-            mock_cleanup.return_value.restart_lbaasv2_agent_systemd.call_count,
-            0
-        )
+        self.assertEqual(crm_cleanup.call_count, 2)
+        self.assertEqual(systemd_cleanup.call_count, 0)
 
     @mock.patch('neutron-evacuate-lbaasv2-agent.'
                 'EvacuateLbaasV2Agent.loadbalancers_on_agent')
     @mock.patch('neutron-evacuate-lbaasv2-agent.'
-                'RemoteLbaasV2Cleanup')
+                'restart_lbaasv2_agent_crm')
+    @mock.patch('neutron-evacuate-lbaasv2-agent.'
+                'restart_lbaasv2_agent_systemd')
     def test_restarts_agents_using_systemd_no_ha(self,
-                                                 mock_cleanup,
+                                                 systemd_restart,
+                                                 crm_restart,
                                                  mock_lbaas):
         mock_lbaas.return_value = ['lb1']
         evacuate_lbaas.cfg.CONF.set_override("use_crm", False)
         self.evacuate_lbaas.run()
         self.assertEqual(
-            mock_cleanup.return_value.restart_lbaasv2_agent_crm.call_count,
+            crm_restart.call_count,
             0
         )
         self.assertEqual(
-            mock_cleanup.return_value.restart_lbaasv2_agent_systemd.call_count,
+            systemd_restart.call_count,
             2
         )

--- a/files/default/test-neutron-ha-tool.py
+++ b/files/default/test-neutron-ha-tool.py
@@ -380,8 +380,8 @@ class TestSshDeleteRouterNamespace(unittest.TestCase):
 
         mock_client.exec_command.side_effect = ssh_exec_side_effect
 
-        ns_cleanup = ha_tool.RemoteRouterNsCleanup("host1")
-        ns_cleanup.delete_router_namespace("routerid1")
+        ha_tool.destroy_router_namespace('host1', 'routerid1')
+
         expected_calls = [
             mock.call("ip netns list", get_pty=mock.ANY, timeout=mock.ANY),
             mock.call("ip netns pids qrouter-routerid1", get_pty=mock.ANY,
@@ -407,10 +407,9 @@ class TestSshDeleteRouterNamespace(unittest.TestCase):
                 mock_stdout.readlines.return_value = ["qrouter-otherid\r\n"]
             return [mock.MagicMock(), mock_stdout, mock.MagicMock()]
 
-        ns_cleanup = ha_tool.RemoteRouterNsCleanup("host1")
         mock_client.exec_command.side_effect = \
             side_effect_namespace_absent
-        ns_cleanup.delete_router_namespace("routerid1")
+        ha_tool.destroy_router_namespace('host1', 'routerid1')
         mock_client.exec_command.assert_called_once_with(
             "ip netns list", timeout=mock.ANY, get_pty=mock.ANY)
 
@@ -421,8 +420,7 @@ class TestSshDeleteRouterNamespace(unittest.TestCase):
 
         mock_client.exec_command.side_effect = \
             side_effect_ssh_connect
-        ns_cleanup = ha_tool.RemoteRouterNsCleanup("host1")
-        ns_cleanup.delete_router_namespace("routerid1")
+        ha_tool.destroy_router_namespace('host1', 'routerid1')
 
 
 class TestAgentIdBasedAgentPicker(unittest.TestCase):

--- a/files/default/test-neutron-ha-tool.py
+++ b/files/default/test-neutron-ha-tool.py
@@ -3,7 +3,6 @@ import datetime
 import unittest
 import collections
 import importlib
-import logging
 import tempfile
 import mock
 import socket
@@ -518,7 +517,7 @@ class TestArgumentParsing(unittest.TestCase):
         self.assertEqual('host', params.target_host)
 
 
-def signal_tester(queue):
+def signal_harness(queue):
     import importlib
     import time
     import sys
@@ -545,7 +544,7 @@ class TestSignalHandling(unittest.TestCase):
     def test_term_signal_handling_functionality(self):
         queue = multiprocessing.Queue()
 
-        proc = multiprocessing.Process(target=signal_tester, args=(queue,))
+        proc = multiprocessing.Process(target=signal_harness, args=(queue,))
         proc.start()
         self.assertEquals('started critical block', queue.get())
         proc.terminate()
@@ -669,8 +668,3 @@ class TestAgentRebalancing(unittest.TestCase):
         self.assertEqual(
             [5], get_router_distribution(neutron_client)
         )
-
-
-if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
-    unittest.main()

--- a/files/default/test-neutron-ha-tool.py
+++ b/files/default/test-neutron-ha-tool.py
@@ -688,3 +688,10 @@ class TestAgentRebalancing(unittest.TestCase):
         self.assertEqual(
             [5], get_router_distribution(neutron_client)
         )
+
+
+class TestSSHHost(unittest.TestCase):
+    @mocked_ssh_client
+    def test_str_prints_hostname(self, ssh_client):
+        with ha_tool.connect_to_host('somehost', 10) as ssh_host:
+            self.assertEqual('somehost', str(ssh_host))

--- a/files/default/test-neutron-ha-tool.py
+++ b/files/default/test-neutron-ha-tool.py
@@ -695,3 +695,10 @@ class TestSSHHost(unittest.TestCase):
     def test_str_prints_hostname(self, ssh_client):
         with ha_tool.connect_to_host('somehost', 10) as ssh_host:
             self.assertEqual('somehost', str(ssh_host))
+
+    @mocked_ssh_client
+    def test_connect_timeout(self, ssh_client):
+        with ha_tool.connect_to_host('somehost', 10):
+            pass
+
+        ssh_client.connect.assert_called_once_with('somehost', timeout=10)

--- a/files/default/test-requirements.txt
+++ b/files/default/test-requirements.txt
@@ -1,6 +1,7 @@
 coverage
 flake8
 mock
+nose
 
 retrying
 paramiko


### PR DESCRIPTION
We agreed to clean up after the lbaasv2 management script has been merged, so that's the goal of this PR.

# TODOS
 - [x] Fix testing and cover all files with flake8
 - [x] Unify classes - so `RemoteRouterNSCleanup` and `RemoteLbaasV2Cleanup`'s public functions look alike, refactor them so to re-use network namespace cleanup methods.
 - [x] Extract Host and methods to connect to SSH
 - [x] Create Namespace class for managing namespaces living on a Host

# Remaining issues
 - [ ] Still, socket.timeout sneaks in to exception handling - I suggest we make top-level methods swallow the exceptions, it doesn't make sense to handle timeout separately - also it doesn't handle exceptions that might occur during connection. This needs to be specified what behavior do we want
 - [ ] timeouts. Now it became clear that we are talking about 2 timeouts. One is to run a command, and the other is to connect to a host. We need to make sure that for blocking operations the timeout is sufficient. Also I am not sure if the timeout in `exec_command` is the one we need. That needs to be tested separately.
 - [ ] lbaasv2 movement scripts are not tested properly, we need to cover them. Now that we have better abstractions, it should be easier to test them.