### PR TITLE
Check agent liveness while migrating

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ python:
 install:
     - pip install -r files/default/test-requirements.txt
 script:
-    - flake8 neutron-ha-tool.py test-neutron-ha-tool.py 
-    - flake8 neutron-evacuate-lbaasv2-agent.py test-neutron-evacuate-lbaasv2-agent.py
-    - python files/default/test-neutron-ha-tool.py
-    - python files/default/test-neutron-evacuate-lbaasv2-agent.py
+    - flake8 *.py
+    - cd files/default && nosetests -v
 

--- a/files/default/README.md
+++ b/files/default/README.md
@@ -6,12 +6,12 @@ Make a python 2 virtual environment, activate it, and install the requirements:
 
 Run the tests
 
-    coverage run test-neutron-ha-tool.py
+    coverage run $(which nosetests) .
 
 Coverage report
 
-    coverage report -i neutron-ha-tool.py
+    coverage report -i $(pwd)/*.py
 
 Code analysis
 
-    flake8 neutron-ha-tool.py test-neutron-ha-tool.py
+    flake8 *.py

--- a/files/default/neutron-evacuate-lbaasv2-agent.py
+++ b/files/default/neutron-evacuate-lbaasv2-agent.py
@@ -38,7 +38,6 @@ except ImportError:
         '', os.path.join(dirname, '/usr/bin/neutron-ha-tool'))
 
 
-
 class EvacuateLbaasV2Agent(object):
 
     def __init__(self):
@@ -157,8 +156,7 @@ class EvacuateLbaasV2Agent(object):
                 self.reassign_loadbalancers(load_balancers, target_agents)
             )
 
-            if (cfg.CONF.source_agent_restart or
-                cfg.CONF.delete_namespaces):
+            if (cfg.CONF.source_agent_restart or cfg.CONF.delete_namespaces):
                 # Make sure the source agent is handled first
                 agents_to_restart.insert(0, self.host_to_evacuate)
 
@@ -167,15 +165,13 @@ class EvacuateLbaasV2Agent(object):
             for host in agents_to_restart:
                 LOG.info("restarting agent on %s" % host)
                 cleanup = RemoteLbaasV2Cleanup(host, timeout=30)
-                if (host != self.host_to_evacuate or
-                    cfg.CONF.source_agent_restart):
+                if (host != self.host_to_evacuate or cfg.CONF.source_agent_restart):  # noqa
                     if cfg.CONF.use_crm:
                         cleanup.restart_lbaasv2_agent_crm()
                     else:
                         cleanup.restart_lbaasv2_agent_systemd()
 
-                if (host == self.host_to_evacuate and
-                    cfg.CONF.delete_namespaces):
+                if (host == self.host_to_evacuate and cfg.CONF.delete_namespaces):  # noqa
                     cleanup.delete_lbaasv2_namespaces(load_balancers)
         else:
             LOG.info("The agent on %s is not hosting any loadbalancers.",

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -639,6 +639,8 @@ def migrate_l3_routers_from_agent(qclient, agent, targets, agent_picker,
             errors += 1
             if fail_fast:
                 break
+        elif migration_result.skipped:
+            return (migrations, errors)
 
     return (migrations, errors)
 

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -426,7 +426,7 @@ class AgentList(object):
 def l3_agent_check(qclient):
     """
     Walk the l3 agents searching for agents that are offline.  Show routers
-    that are offline and where we would migrate them to.
+    that are offline.
 
     :param qclient: A neutronclient
     :returns: total numbers of migrations required
@@ -448,16 +448,8 @@ def l3_agent_check(qclient):
         routers = list_routers_on_l3_agent(qclient, agent['id'])
 
         for router in routers:
-            try:
-                target = random.choice(agent_alive_list)
-            except IndexError:
-                LOG.warn("There are no l3 agents alive we could "
-                         "migrate routers onto.")
-                target = {'id': None}
-
+            LOG.warn("Would like to migrate router=%s", router['id'])
             migration_count += 1
-            LOG.warn("Would like to migrate router=%s to agent=%s",
-                     router['id'], target['id'])
 
     return migration_count
 

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -640,6 +640,10 @@ def migrate_l3_routers_from_agent(qclient, agent, targets, agent_picker,
             if fail_fast:
                 break
         elif migration_result.skipped:
+            LOG.info(
+                "Migration of router %s was skipped, no more routers will be "
+                "moved away from agent %s", router['id'], agent['id']
+            )
             return (migrations, errors)
 
     return (migrations, errors)
@@ -652,6 +656,10 @@ def migrate_router_safely(qclient, noop, router, agent, target,
         all_agents = list_agents(qclient)
         live_agents = list_alive_agents(all_agents, 'L3 agent')
         if agent['id'] in [_agent['id'] for _agent in live_agents]:
+            LOG.info(
+                "Agent %s is online, not migrating router %s",
+                agent['id'], router['id']
+            )
             return SKIPPED_MIGRATION
     if noop:
         LOG.info("Would try to migrate router=%s from agent=%s "

--- a/files/default/test-neutron-evacuate-lbaasv2-agent.py
+++ b/files/default/test-neutron-evacuate-lbaasv2-agent.py
@@ -80,7 +80,3 @@ class TestEvacuateLbaasV2Agents(unittest.TestCase):
             mock_cleanup.return_value.restart_lbaasv2_agent_systemd.call_count,
             2
         )
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/files/default/test-neutron-ha-tool.py
+++ b/files/default/test-neutron-ha-tool.py
@@ -3,7 +3,6 @@ import datetime
 import unittest
 import collections
 import importlib
-import logging
 import tempfile
 import mock
 import socket
@@ -518,7 +517,7 @@ class TestArgumentParsing(unittest.TestCase):
         self.assertEqual('host', params.target_host)
 
 
-def signal_tester(queue):
+def signal_harness(queue):
     import importlib
     import time
     import sys
@@ -545,7 +544,7 @@ class TestSignalHandling(unittest.TestCase):
     def test_term_signal_handling_functionality(self):
         queue = multiprocessing.Queue()
 
-        proc = multiprocessing.Process(target=signal_tester, args=(queue,))
+        proc = multiprocessing.Process(target=signal_harness, args=(queue,))
         proc.start()
         self.assertEquals('started critical block', queue.get())
         proc.terminate()
@@ -669,8 +668,3 @@ class TestAgentRebalancing(unittest.TestCase):
         self.assertEqual(
             [5], get_router_distribution(neutron_client)
         )
-
-
-if __name__ == "__main__":
-    logging.basicConfig(level=logging.DEBUG)
-    unittest.main()

--- a/files/default/test-requirements.txt
+++ b/files/default/test-requirements.txt
@@ -1,6 +1,7 @@
 coverage
 flake8
 mock
+nose
 
 retrying
 paramiko


### PR DESCRIPTION
This change makes sure that agent liveness is checked before migrating a router in `l3-agent-migrate` mode.

Please note that the first commit is part of another PR (#30) as well (a small cleanup commit)