### PR TITLE
Better help message for --l3-agent-evacuate

### DIFF
--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -73,7 +73,7 @@ def make_argparser():
     ap.add_argument('--l3-agent-migrate', action='store_true', default=False,
                     help='Migrate routers away from offline l3 agents')
     ap.add_argument('--l3-agent-evacuate', default=None, metavar='HOST',
-                    help='Migrate routers away from a particular l3 agent')
+                    help='Migrate routers away from l3 agent living on HOST')
     ap.add_argument('--l3-agent-rebalance', action='store_true', default=False,
                     help='Rebalance router count on all l3 agents')
     ap.add_argument('--replicate-dhcp', action='store_true', default=False,


### PR DESCRIPTION
Although the metavar used was HOST, the help message was still referring
to an agent, making it hard to guess what the parameter should be.
Amending the help message to make it clear.