### PR TITLE
Some fixes for router migration

### DIFF
--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -712,7 +712,10 @@ def migrate_router(qclient, router, agent, target,
             LOG.debug("The router was not correctly deleted from agent=%s, "
                       "retrying." % agent['id'])
 
-        if router in list_routers_on_l3_agent(qclient, agent['id']):
+        router_ids = [
+            r['id'] for r in list_routers_on_l3_agent(qclient, agent['id'])
+        ]
+        if router['id'] in router_ids:
             raise RuntimeError("Failed to remove router_id=%s from agent_id="
                                "%s" % (router['id'], agent['id']))
 

--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -709,7 +709,10 @@ def migrate_router(qclient, router, agent, target,
             LOG.debug("The router was not correctly deleted from agent=%s, "
                       "retrying." % agent['id'])
 
-        if router_is_on_agent(qclient, router, agent):
+            if router_is_on_agent(qclient, router, agent):
+                raise RuntimeError("Failed to remove router_id=%s from agent_id="
+                                   "%s" % (router['id'], agent['id']))
+        else:
             raise RuntimeError("Failed to remove router_id=%s from agent_id="
                                "%s" % (router['id'], agent['id']))
 


### PR DESCRIPTION
Added some fixes of router migration. The most important change is that we might have falsely reported that a router was deleted from the source agents, because we were not checking the router ids, we were expecting to see the same router dictionary from different api requests. Also some cosmetics applied to the code while I was there.