### PR TITLE
neutron-ha-tool: Increase router migration timeout (SOC-11046)

### DIFF
--- a/files/default/neutron-ha-tool.py
+++ b/files/default/neutron-ha-tool.py
@@ -753,7 +753,7 @@ def migrate_router(qclient, router, agent, target,
         nscleanup.delete_router_namespace(router['id'])
 
 
-def wait_router_migrated(qclient, router_id, target_host, maxtries=60,
+def wait_router_migrated(qclient, router_id, target_host, maxtries=120,
                          state="ACTIVE"):
     """
     Returns nothing. Waits for all non-distributed ports and floating IPs


### PR DESCRIPTION
Router migration was timing out sometimes during scale testing of
upgrade procedure.